### PR TITLE
CSS object and tagName lowercase

### DIFF
--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -2,6 +2,12 @@ import { Component, h, Host, Element, Prop, State } from "@stencil/core";
 import { x24 } from "@esri/calcite-ui-icons";
 import { getItem, setItem } from "../../utils/localStorage";
 
+const CSS = {
+  close: "close",
+  content: "content",
+  link: "link"
+}
+
 @Component({
   tag: "calcite-tip",
   styleUrl: "./calcite-tip.scss",
@@ -13,12 +19,12 @@ export class CalciteTip {
   @Prop() storageId:string;
   @Prop() dismissible = true;
 
-  @State() dismissed = getItem(`calcite-tip-${this.storageId}`) !== null;
+  @State() dismissed = getItem(`${this.el.tagName.toLowerCase()}-${this.storageId}`) !== null;
 
   hideTip() {
     this.dismissed = true;
     if (this.storageId) {
-      setItem(`calcite-tip-${this.storageId}`, "dismissed");
+      setItem(`${this.el.tagName.toLowerCase()}-${this.storageId}`, "dismissed");
     }
   }
 
@@ -26,17 +32,17 @@ export class CalciteTip {
     return (
       <Host hidden={this.dismissed}>
         <slot name="heading" />
-        { this.dismissible ? <div class="close" onClick={() => this.hideTip()}>
+        { this.dismissible ? <div class={CSS.close} onClick={() => this.hideTip()}>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path d={x24} />
           </svg>
         </div> : null }
-        <div class="content">
+        <div class={CSS.content}>
           <slot name="thumbnail" />
           <div>
             <slot />
             {!!this.el.querySelector("[slot=link]") ? (
-              <p class="link">
+              <p class={CSS.link}>
                 <slot name="link" />
               </p>
             ) : null}


### PR DESCRIPTION
**Related Issue:** #4

## Summary
- Using `.this.el.tagName` prefix for localStorage Id to address: https://github.com/ArcGIS/calcite-app-components/pull/33/files#r293229352
- Added a CSS Object for classnames.