### PR TITLE
Add a theme attribute to components that will default to the closest parent theme

### DIFF
--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -1,4 +1,14 @@
-import { Component, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Host,
+  Prop,
+  h
+} from "@stencil/core";
+
+import { getElementTheme } from "../../utils/dom";
 
 const CSS = {
   button: "calcite-action__button",
@@ -14,6 +24,14 @@ const CSS = {
 export class CalciteAction {
   // --------------------------------------------------------------------------
   //
+  //  Private Properties
+  //
+  // --------------------------------------------------------------------------
+
+  @Element() el: HTMLElement;
+
+  // --------------------------------------------------------------------------
+  //
   //  Properties
   //
   // --------------------------------------------------------------------------
@@ -27,6 +45,8 @@ export class CalciteAction {
   @Prop() text: string;
 
   @Prop({ reflect: true }) textEnabled = false;
+
+  @Prop({ reflect: true }) theme = getElementTheme(this.el);
 
   // --------------------------------------------------------------------------
   //

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,4 @@
+export function getElementTheme(el: HTMLElement): string {
+  const closestEl = el.closest("[theme]");
+  return (closestEl && closestEl.getAttribute("theme")) || "light";
+}


### PR DESCRIPTION
## Summary

Proposal: Add a theme attribute to components that will default to the closest parent theme

## Background

We want individual components to be able to have a theme set but we would also like the default theme to inherit from its parent.

This PR introduces a helper function `getElementTheme(el: HTMLElement)`.

Users can still explicitly set a theme but if they don't it will use the closest parent theme as the default theme.

## Potential issue:

Another component that isn't a `calcite-component` uses the same `theme` attribute as well.

## Proposed solutions

- Use `calcite-theme` attribute instead.
- Only support themes with the `calcite` name inside them. ex: `theme="calcite-dark"`
