### PR TITLE
Issue #63: Enable newline TSLint rules.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12631,6 +12631,12 @@
         }
       }
     },
+    "tslint-lines-between-class-members": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/tslint-lines-between-class-members/-/tslint-lines-between-class-members-1.3.4.tgz",
+      "integrity": "sha512-nxyY0cakXEYsDjR8KJQF/nooa/zwn9aP/a2rY0oYe+Nv4kqVrt7bp4x+CCyMVyMln50Fxo3dSkoc+BMo75oSBA==",
+      "dev": true
+    },
     "tslint-stencil": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tslint-stencil/-/tslint-stencil-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "tslint": "5.17.0",
     "tslint-config-prettier": "1.18.0",
     "tslint-ionic-rules": "0.0.21",
+    "tslint-lines-between-class-members": "1.3.4",
     "tslint-stencil": "1.0.1"
   },
   "license": "MIT"

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,13 @@
     },
     "decorated-member-style": {
       "severity": "off"
+    },
+    "lines-between-class-members": {
+      "options": [1]
+    },
+    "no-consecutive-blank-lines": {
+      "options": [1]
     }
-  }
+  },
+  "rulesDirectory": ["node_modules/tslint-lines-between-class-members"]
 }


### PR DESCRIPTION
**Related Issue:** #63

## Summary

Adds auto-fixable TSLint rules for:

* Enforcing a newline between methods.
* Removing consecutive newlines (>1).

Note that the enforced min newline rule only applies to methods. I have not found a rule to handle other class members ([`tslint-lines-between-class-members` matches ESLint's similarly-named rule which only covers methods](https://github.com/chinchiheather/tslint-lines-between-class-members/issues/11)). We'll have to use the example component to establish newline conventions for non-method members.