### PR TITLE
Comment out helper text in Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -16,4 +16,4 @@ assignees: ""
 
 1.
 
-### Relevant Info <small>(e.g. Browser, OS, Mobile,)</small>
+### Relevant Info <!--(e.g. Browser, OS, Mobile,)-->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -8,7 +8,7 @@ assignees: ""
 
 ### Description
 
-### Acceptance Criteria <small>(a.k.a. Requirements)</small>
+### Acceptance Criteria <!--(a.k.a. Requirements)-->
 
 #### Desired New Behavior
 
@@ -16,7 +16,7 @@ assignees: ""
 
 #### Out of Scope
 
-### Relevant Info <small>(e.g. Dependencies, Blockers)</small>
+### Relevant Info <!--(e.g. Dependencies, Blockers)-->
 
 ### Helpful Details
 

--- a/.github/ISSUE_TEMPLATE/new-component.md
+++ b/.github/ISSUE_TEMPLATE/new-component.md
@@ -10,12 +10,12 @@ assignees: ""
 
 #### User Stories
 
-### Acceptance Criteria <small>(a.k.a. Requirements)</small>
+### Acceptance Criteria <!--(a.k.a. Requirements)-->
 
 #### Desired Behavior
 
 #### Desired Look & Feel
 
-#### Out of Scope <small>(anything not v1)</small>
+#### Out of Scope <!--(anything not v1)-->
 
 ### Helpful Details

--- a/.github/ISSUE_TEMPLATE/tooling.md
+++ b/.github/ISSUE_TEMPLATE/tooling.md
@@ -14,4 +14,4 @@ assignees: ""
 
 **Desired outcome:**
 
-### Resources <small>(e.g. links to libraries or code snippets)</small>
+### Resources <!--(e.g. links to libraries or code snippets)-->


### PR DESCRIPTION
**Related Issue:** none

## Summary
The `<small>` tag doesn't work in markdown like I expected, and the helper text is noise unless you manually delete it when creating an issue.
Changing the helper text to comments means it still appears during issue creation, but it won't appear after the issue is created and doesn't need to be deleted.

Question: Do you guys prefer the comments adjacent to the heading, or below the heading (like the research template?)
