### PR TITLE
Update and fix calcite dep versions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -235,8 +235,8 @@
       }
     },
     "@esri/calcite-base": {
-      "version": "github:ArcGIS/calcite-base#ea0fc88cecd8490351fa4dbffc1e983b2c6af299",
-      "from": "github:ArcGIS/calcite-base"
+      "version": "github:ArcGIS/calcite-base#3d18d243f5d2d9fb80a450b7a4950381a6048f1d",
+      "from": "github:ArcGIS/calcite-base#3d18d24"
     },
     "@esri/calcite-colors": {
       "version": "1.2.1",
@@ -1274,16 +1274,26 @@
       "version": "github:ArcGIS/calcite-components#2d88b530eaeb4ddb905effc2c718bee5722e6005",
       "from": "github:ArcGIS/calcite-components#v0.0.0-alpha.4",
       "requires": {
-        "@esri/calcite-base": "github:ArcGIS/calcite-base#ea0fc88cecd8490351fa4dbffc1e983b2c6af299",
+        "@esri/calcite-base": "github:ArcGIS/calcite-base",
         "@esri/calcite-colors": "^1.2.0",
         "@esri/calcite-ui-icons": "^2.0.1",
-        "calcite-fonts": "github:ArcGIS/calcite-fonts#278f9aac7b4fde778d30ae2a7fa466c3d11a9977",
+        "calcite-fonts": "github:ArcGIS/calcite-fonts",
         "npm-run-all": "4.1.5"
+      },
+      "dependencies": {
+        "@esri/calcite-base": {
+          "version": "github:ArcGIS/calcite-base#3d18d243f5d2d9fb80a450b7a4950381a6048f1d",
+          "from": "github:ArcGIS/calcite-base"
+        },
+        "calcite-fonts": {
+          "version": "github:ArcGIS/calcite-fonts#278f9aac7b4fde778d30ae2a7fa466c3d11a9977",
+          "from": "github:ArcGIS/calcite-fonts"
+        }
       }
     },
     "calcite-fonts": {
-      "version": "github:ArcGIS/calcite-fonts#278f9aac7b4fde778d30ae2a7fa466c3d11a9977",
-      "from": "github:ArcGIS/calcite-fonts"
+      "version": "github:ArcGIS/calcite-fonts#661879e18bd9c5e6ea1b8917959aae8b1ba91812",
+      "from": "github:ArcGIS/calcite-fonts#v1.1.2"
     },
     "caller-callsite": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "url": "git+https://github.com/ArcGIS/calcite-app-components.git"
   },
   "dependencies": {
-    "@esri/calcite-base": "github:ArcGIS/calcite-base",
-    "@esri/calcite-colors": "^1.2.0",
-    "@esri/calcite-ui-icons": "^2.0.1",
-    "calcite-components": "github:ArcGIS/calcite-components.git#v0.0.0-alpha.4",
-    "calcite-fonts": "github:ArcGIS/calcite-fonts"
+    "@esri/calcite-base": "github:ArcGIS/calcite-base#3d18d24",
+    "@esri/calcite-colors": "1.2.1",
+    "@esri/calcite-ui-icons": "2.0.1",
+    "calcite-components": "github:ArcGIS/calcite-components#v0.0.0-alpha.4",
+    "calcite-fonts": "github:ArcGIS/calcite-fonts#v1.1.2"
   },
   "devDependencies": {
     "@stencil/core": "1.1.3",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

* Fixes the version for all calcite dependencies.
  - `calcite-base` points to a commit since the repo hasn't set up tags.
* Bumps `calcite-colors` to the latest version.

I did a quick test (demo page & ran tests) and didn't notice any issues.

