### PR TITLE
Tidy up calcite-block-section test suite.

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.e2e.ts
+++ b/src/components/calcite-block-section/calcite-block-section.e2e.ts
@@ -28,31 +28,51 @@ describe("calcite-block-section", () => {
     expect(element).toBeNull();
   });
 
+  it("can display/hide content", async () => {
+    const page = await newE2EPage();
+    await page.setContent("<calcite-block-section><div>some content</div></calcite-block-section>");
+    let element = await page.find("calcite-block-section");
+    let content = await page.find(`calcite-block-section >>> .${CSS.content}`);
+
+    expect(await content.isVisible()).toBe(false);
+
+    element.setProperty("open", true);
+    await page.waitForChanges();
+    element = await page.find("calcite-block-section[open]");
+    content = await page.find(`calcite-block-section >>> .${CSS.content}`);
+
+    expect(element).toBeTruthy();
+    expect(await content.isVisible()).toBe(true);
+
+    element.setProperty("open", false);
+    await page.waitForChanges();
+    element = await page.find("calcite-block-section[open]");
+    content = await page.find(`calcite-block-section >>> .${CSS.content}`);
+
+    expect(element).toBeNull();
+    expect(await content.isVisible()).toBe(false);
+  });
+
   it("can be toggled", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-block-section></calcite-block-section>");
     const element = await page.find("calcite-block-section");
-    const content = await page.find(`calcite-block-section >>> .${CSS.content}`);
     const toggleSpy = await element.spyOnEvent("calciteBlockSectionToggle");
     const toggle = await page.find(`calcite-block-section >>> calcite-action`);
 
-    expect(await element.getProperty("open")).toBe(false);
-    expect(await content.isVisible()).toBe(false);
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
 
     await toggle.click();
 
-    expect(await element.getProperty("open")).toBe(true);
-    expect(await content.isVisible()).toBe(true);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
     expect(toggleSpy).toHaveReceivedEventTimes(1);
+    expect(await element.getProperty("open")).toBe(true);
+    expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
 
     await toggle.click();
 
-    expect(await element.getProperty("open")).toBe(false);
-    expect(await content.isVisible()).toBe(false);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
     expect(toggleSpy).toHaveReceivedEventTimes(2);
+    expect(await element.getProperty("open")).toBe(false);
+    expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
   });
 
   it("sets calcite-block-section renders section text", async () => {

--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -60,16 +60,14 @@ describe("calcite-block", () => {
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(1);
-    let open = await element.getProperty("open");
-    expect(open).toBe(true);
+    expect(await element.getProperty("open")).toBe(true);
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
     expect(toggle.getAttribute("title")).toBe(TEXT.collapse);
 
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(2);
-    open = await element.getProperty("open");
-    expect(open).toBe(false);
+    expect(await element.getProperty("open")).toBe(false);
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
     expect(toggle.getAttribute("title")).toBe(TEXT.expand);
   });


### PR DESCRIPTION
**Related Issue:** #121  

## Summary

Drops duplicate tests that are covered by the *"can be toggled"* test assertions.

cc @asangma 