### PR TITLE
Replace toggleAttribute with setAttribute

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -132,7 +132,7 @@ export class CalciteActionBar {
     this.el
       .querySelectorAll("calcite-action")
       .forEach((action) =>
-        newValue ? action.toggleAttribute("text-enabled") : action.removeAttribute("text-enabled")
+        newValue ? action.setAttribute("text-enabled", "") : action.removeAttribute("text-enabled")
       );
   }
 

--- a/src/components/calcite-floating-panel/calcite-floating-panel.tsx
+++ b/src/components/calcite-floating-panel/calcite-floating-panel.tsx
@@ -103,6 +103,6 @@ export class CalciteFloatingPanel {
   }
 
   hidePanel = () => {
-    this.el.toggleAttribute("hidden", true);
+    this.el.setAttribute("hidden", "");
   };
 }

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -109,21 +109,22 @@ export class CalciteTipManager {
     this.selectedIndex = selectedTip ? tips.indexOf(selectedTip) : 0;
 
     tips.forEach((tip) => {
-      tip.toggleAttribute("non-dismissible", true);
+      tip.setAttribute("non-dismissible", "");
     });
     this.showSelectedTip();
     this.updateGroupTitle();
   }
 
   hideTipManager = (): void => {
-    this.el.toggleAttribute("hidden");
-    this.el.toggleAttribute("aria-hidden");
+    this.el.setAttribute("hidden", "");
+    this.el.setAttribute("aria-hidden", "");
   };
 
   showSelectedTip() {
     this.tips.forEach((tip, index) => {
-      tip.toggleAttribute("selected", this.selectedIndex === index);
-      tip.toggleAttribute("hidden", this.selectedIndex !== index);
+      const isSelected = this.selectedIndex === index;
+      isSelected ? tip.setAttribute("selected", "") : tip.removeAttribute("selected");
+      isSelected ? tip.removeAttribute("hidden") : tip.setAttribute("hidden", "");
     });
   }
 

--- a/src/demos/calcite-shell.html
+++ b/src/demos/calcite-shell.html
@@ -580,7 +580,7 @@
       var actionPad = document.getElementById("action-pad");
       var actionPadButton = document.getElementById("action-pad-button");
       actionPadButton.addEventListener("click", function() {
-        actionPad.hasAttribute("hidden") ? actionPad.removeAttribute("hidden") : actionPad.toggleAttribute("hidden");
+        actionPad.hasAttribute("hidden") ? actionPad.removeAttribute("hidden") : actionPad.setAttribute("hidden", "");
 
         actionPad.positionElement = actionPadButton;
       });
@@ -590,7 +590,7 @@
       floatingPanelButton.addEventListener("click", function() {
         floatingPanel.hasAttribute("hidden")
           ? floatingPanel.removeAttribute("hidden")
-          : floatingPanel.toggleAttribute("hidden");
+          : floatingPanel.setAttribute("hidden", "");
 
         floatingPanel.positionElement = floatingPanelButton;
       });
@@ -600,7 +600,7 @@
       floatingPanelOverButton.addEventListener("click", function() {
         floatingPanelOver.hasAttribute("hidden")
           ? floatingPanelOver.removeAttribute("hidden")
-          : floatingPanelOver.toggleAttribute("hidden");
+          : floatingPanelOver.setAttribute("hidden", "");
 
         floatingPanelOver.positionElement = floatingPanelOverButton;
       });


### PR DESCRIPTION
**Related Issue:** #100 

## Summary

Bug: Tips are showing their close button in Tip Manager in Edge #100

#100 don't use toggleAttribute :(

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/ArcGIS/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
