### PR TITLE
fix edge styling issues with slots

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -6,9 +6,7 @@ import { CalciteLayout, CalciteTheme } from "../interfaces";
 
 import { getElementDir } from "calcite-components/dist/collection/utils/dom";
 
-const CSS = {
-  actionGroupBottom: "action-group--bottom"
-};
+import { CSS } from "./resources";
 
 @Component({
   tag: "calcite-action-bar",
@@ -106,7 +104,9 @@ export class CalciteActionBar {
 
     return this.el.querySelector("[slot=bottom-actions]") || expandToggleNode ? (
       <calcite-action-group class={CSS.actionGroupBottom}>
-        <slot name="bottom-actions" />
+        <div class={CSS.actionGroupBottomContainer}>
+          <slot name="bottom-actions" />
+        </div>
         {expandToggleNode}
       </calcite-action-group>
     ) : null;

--- a/src/components/calcite-action-bar/resources.ts
+++ b/src/components/calcite-action-bar/resources.ts
@@ -1,0 +1,4 @@
+export const CSS = {
+  actionGroupBottom: "action-group--bottom",
+  actionGroupBottomContainer: "action-group-bottom-container"
+};

--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -63,7 +63,7 @@ h2.heading {
   position: relative;
 }
 
-.menu slot[name="menu-actions"] {
+.menu {
   position: absolute;
   top: 100%;
   z-index: 1;
@@ -78,6 +78,11 @@ h2.heading {
   flex-flow: column nowrap;
   border: 1px solid var(--calcite-app-border);
   animation: calcite-app-fade-in-down var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function);
+  display: none;
+}
+
+.menu--open {
+  display: block;
 }
 
 .content-container {
@@ -87,7 +92,7 @@ h2.heading {
   overflow: auto;
 }
 
-slot[name="footer-actions"] {
+.footer {
   align-items: center;
   background-color: var(--calcite-app-background);
   border-top: 1px solid var(--calcite-app-border);

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -132,11 +132,11 @@ export class CalciteFlowItem {
   renderMenuActions() {
     const { menuOpen } = this;
 
-    return menuOpen ? (
-      <div class={CSS.menu}>
+    return (
+      <div class={classnames(CSS.menu, { [CSS.menuOpen]: menuOpen })}>
         <slot name="menu-actions" />
       </div>
-    ) : null;
+    );
   }
 
   renderFooterActions() {

--- a/src/components/calcite-flow-item/resources.ts
+++ b/src/components/calcite-flow-item/resources.ts
@@ -8,6 +8,7 @@ export const CSS = {
   menuContainer: "menu-container",
   menuButton: "menu-button",
   menu: "menu",
+  menuOpen: "menu--open",
   contentContainer: "content-container",
   footer: "footer"
 };

--- a/src/components/calcite-tip-group/calcite-tip-group.scss
+++ b/src/components/calcite-tip-group/calcite-tip-group.scss
@@ -1,0 +1,6 @@
+$tip-max-width: 540px;
+
+::slotted(calcite-tip) {
+  max-width: $tip-max-width;
+  padding: 0 var(--calcite-app-side-spacing-half);
+}

--- a/src/components/calcite-tip-group/calcite-tip-group.tsx
+++ b/src/components/calcite-tip-group/calcite-tip-group.tsx
@@ -3,6 +3,7 @@ import { TEXT } from "../calcite-tip-manager/resources";
 
 @Component({
   tag: "calcite-tip-group",
+  styleUrl: "./calcite-tip-group.scss",
   shadow: true
 })
 export class CalciteTipGroup {

--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -53,8 +53,12 @@ $tip-max-width: 540px;
   background-color: var(--calcite-app-background);
 }
 
-slot::slotted(calcite-tip-group),
-slot::slotted(calcite-tip) {
+::slotted(calcite-tip-group) {
+  max-width: $tip-max-width;
+  padding: 0 var(--calcite-app-side-spacing-half);
+}
+
+::slotted(calcite-tip) {
   max-width: $tip-max-width;
   padding: 0 var(--calcite-app-side-spacing-half);
 }

--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -50,7 +50,7 @@ $tip-image-max-width: 100% !default;
   margin-top: 0;
 }
 
-slot[name="link"]::slotted(a) {
+.info ::slotted(a) {
   color: var(--calcite-app-foreground);
 }
 


### PR DESCRIPTION
**Related Issue:** none

## Summary

Fixes edge styling issues involving slots.

- cannot use `slot` as selector since the polyfill wont find it
- to keep dom placement ordering correct for slots, sometimes a container is needed
- conditional slot containers don't seem to work in edge
- added resources file