### PR TITLE
Issue: 147: Rename supporting interfaces file so it gets included in dist

### DIFF
--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -1,3 +1,5 @@
+/* Note: using `.d.ts` file extension will exclude it from the output build */
+
 export type CalcitePlacement = "side" | "over" | "anchor";
 
 export type CalciteLayout = "leading" | "trailing";


### PR DESCRIPTION
**Related Issue:** #147

## Summary

Rename `interfaces.d.ts` => `interfaces.ts` so the Stencil build includes it in the output build.