### PR TITLE
Add i18n strings for tip buttons

### DIFF
--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -17,6 +17,11 @@ export class CalciteTipManager {
   //
   // --------------------------------------------------------------------------
   /**
+   * Alternate text for closing the Tip Manager.
+   */
+  @Prop() textClose = "Close";
+
+  /**
    * The default group title for the Tip Manager.
    */
   @Prop({ reflect: true }) textDefaultTitle = TEXT.defaultGroupTitle;
@@ -24,6 +29,16 @@ export class CalciteTipManager {
    * Label that appears on hover of pagination icon.
    */
   @Prop({ reflect: true }) textPaginationLabel = TEXT.defaultPaginationLabel;
+
+  /**
+   * Alternate text for navigating to the previous tip.
+   */
+  @Prop() textPrevious = "Previous";
+
+  /**
+   * Alternate text for navigating to the next tip.
+   */
+  @Prop() textNext = "Next";
 
   /**
    * Used to set the component's color scheme.
@@ -157,7 +172,7 @@ export class CalciteTipManager {
       <Host>
         <header class={CSS.header}>
           <h2 class={CSS.heading}>{this.groupTitle}</h2>
-          <calcite-action onClick={this.hideTipManager} class={CSS.close}>
+          <calcite-action text={this.textClose} onClick={this.hideTipManager} class={CSS.close}>
             <CalciteIcon size="16" path={x16} />
           </calcite-action>
         </header>
@@ -165,13 +180,17 @@ export class CalciteTipManager {
           <slot />
         </div>
         <footer class={CSS.pagination}>
-          <calcite-action onClick={this.previousClicked} class={CSS.pagePrevious}>
+          <calcite-action
+            text={this.textPrevious}
+            onClick={this.previousClicked}
+            class={CSS.pagePrevious}
+          >
             <CalciteIcon size="16" path={chevronLeft16} />
           </calcite-action>
           <span class={CSS.pagePosition}>
             {`${this.textPaginationLabel} ${this.selectedIndex + 1}/${this.total}`}
           </span>
-          <calcite-action onClick={this.nextClicked} class={CSS.pageNext}>
+          <calcite-action text={this.textNext} onClick={this.nextClicked} class={CSS.pageNext}>
             <CalciteIcon size="16" path={chevronRight16} />
           </calcite-action>
         </footer>

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -19,12 +19,18 @@ export class CalciteTipManager {
   /**
    * Alternate text for closing the Tip Manager.
    */
-  @Prop() textClose = "Close";
+  @Prop() textClose = TEXT.close;
 
   /**
    * The default group title for the Tip Manager.
    */
   @Prop({ reflect: true }) textDefaultTitle = TEXT.defaultGroupTitle;
+
+  /**
+   * Alternate text for navigating to the next tip.
+   */
+  @Prop() textNext = TEXT.next;
+
   /**
    * Label that appears on hover of pagination icon.
    */
@@ -33,12 +39,7 @@ export class CalciteTipManager {
   /**
    * Alternate text for navigating to the previous tip.
    */
-  @Prop() textPrevious = "Previous";
-
-  /**
-   * Alternate text for navigating to the next tip.
-   */
-  @Prop() textNext = "Next";
+  @Prop() textPrevious = TEXT.previous;
 
   /**
    * Used to set the component's color scheme.

--- a/src/components/calcite-tip-manager/resources.ts
+++ b/src/components/calcite-tip-manager/resources.ts
@@ -1,6 +1,9 @@
 export const TEXT = {
   defaultGroupTitle: "Tips",
-  defaultPaginationLabel: "Tip"
+  defaultPaginationLabel: "Tip",
+  close: "Close",
+  previous: "Previous",
+  next: "Next"
 };
 
 export const CSS = {

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -37,6 +37,11 @@ export class CalciteTip {
   @Prop() thumbnail: string;
 
   /**
+   * Alternate text for closing the tip.
+   */
+  @Prop() textClose = "Close";
+
+  /**
    * Alternate text for description of the thumbnail.
    */
   @Prop() textThumbnail: string;
@@ -84,7 +89,7 @@ export class CalciteTip {
         <header class={CSS.header}>
           <h3 class={CSS.heading}>{this.heading}</h3>
           {!this.nonDismissible ? (
-            <calcite-action onClick={this.hideTip} class={CSS.close}>
+            <calcite-action text={this.textClose} onClick={this.hideTip} class={CSS.close}>
               <CalciteIcon size="16" path={x16} />
             </calcite-action>
           ) : null}

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -3,7 +3,7 @@ import { x16 } from "@esri/calcite-ui-icons";
 import { getItem, setItem } from "../../utils/localStorage";
 import CalciteIcon from "../_support/CalciteIcon";
 import { CalciteTheme } from "../interfaces";
-import { CSS } from "./resources";
+import { CSS, TEXT } from "./resources";
 
 @Component({
   tag: "calcite-tip",
@@ -32,19 +32,19 @@ export class CalciteTip {
   @Prop() heading: string;
 
   /**
-   * A string of the path to the thumbnail.
-   */
-  @Prop() thumbnail: string;
-
-  /**
    * Alternate text for closing the tip.
    */
-  @Prop() textClose = "Close";
+  @Prop() textClose = TEXT.close;
 
   /**
    * Alternate text for description of the thumbnail.
    */
   @Prop() textThumbnail: string;
+
+  /**
+   * A string of the path to the thumbnail.
+   */
+  @Prop() thumbnail: string;
 
   /**
    * Used to set the component's color scheme.

--- a/src/components/calcite-tip/resources.ts
+++ b/src/components/calcite-tip/resources.ts
@@ -7,3 +7,7 @@ export const CSS = {
   info: "info",
   link: "link"
 };
+
+export const TEXT = {
+  close: "Close"
+};


### PR DESCRIPTION
**Related Issue:** #104

## Summary

Tip and Tipmanager need strings for some of their buttons.

Add i18n strings for tip buttons

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/ArcGIS/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
