### PR TITLE
update @stencil/core to v1.2.5

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -501,9 +501,9 @@
       }
     },
     "@stencil/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-2T2He4tHHagA7Y8WDh5iWDTtBLSUWZjfp7MA8RgPlT5aDuyo5C0+gSHASnQL2QkM+rrvTywSXhfj0X/QPss4Jw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-4cnilHldBjB+QcVLgYWhsqXLyapFZ+EfPkmTcRLKNNFlNk7iCZFtxG2uh6/oCzx2CG+3Q3YPKbBaIYs5M/5l/g==",
       "dev": true,
       "requires": {
         "typescript": "3.5.3"
@@ -1299,10 +1299,10 @@
       "version": "github:Esri/calcite-components#2d88b530eaeb4ddb905effc2c718bee5722e6005",
       "from": "github:Esri/calcite-components#v0.0.0-alpha.4",
       "requires": {
-        "@esri/calcite-base": "github:ArcGIS/calcite-base",
+        "@esri/calcite-base": "github:ArcGIS/calcite-base#b0c38e5bb47baeda2cdd8543bf468f33034617f3",
         "@esri/calcite-colors": "^1.2.0",
         "@esri/calcite-ui-icons": "^2.0.1",
-        "calcite-fonts": "github:ArcGIS/calcite-fonts",
+        "calcite-fonts": "github:ArcGIS/calcite-fonts#f0cc6bb3a73eb8771405f56e4c83d50af1ca825a",
         "npm-run-all": "4.1.5"
       },
       "dependencies": {
@@ -2479,8 +2479,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2501,14 +2500,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2523,20 +2520,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2653,8 +2647,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2666,7 +2659,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2681,7 +2673,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2689,14 +2680,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2715,7 +2704,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2796,8 +2784,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2809,7 +2796,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2895,8 +2881,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2932,7 +2917,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2952,7 +2936,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2996,14 +2979,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "calcite-fonts": "github:ArcGIS/calcite-fonts#v1.1.2"
   },
   "devDependencies": {
-    "@stencil/core": "1.2.4",
+    "@stencil/core": "1.2.5",
     "@stencil/postcss": "1.0.1",
     "@stencil/sass": "1.0.1",
     "@stencil/state-tunnel": "1.0.1",


### PR DESCRIPTION
## Summary
- Update @stencil/core to v1.2.5
- Also add `.npmrc` file to make save-exact true by default
- All tests are passing.
- Demos look unaffected.