### PR TITLE
#164 add collapsed property to hide content

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -1,5 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 
+import { CSS } from "./resources";
+
 describe("calcite-shell-panel", () => {
   it("renders", async () => {
     const page = await newE2EPage();
@@ -18,7 +20,40 @@ describe("calcite-shell-panel", () => {
     const layout = await element.getProperty("layout");
 
     expect(layout).toBe("leading");
+
+    const collapsed = await element.getProperty("collapsed");
+
+    expect(collapsed).toBe(false);
+
     expect(element.shadowRoot.firstElementChild.tagName).toBe("SLOT");
+  });
+
+  it("should show panel content", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<calcite-shell-panel><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
+    );
+
+    await page.waitForChanges();
+
+    const element = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
+
+    expect(await element.isVisible()).toBe(true);
+  });
+
+  it("collapsed property should hide panel content", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<calcite-shell-panel collapsed><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
+    );
+
+    await page.waitForChanges();
+
+    const element = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
+
+    expect(element).toBeNull();
   });
 
   it("leading layout property should have action slot first ", async () => {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -39,7 +39,9 @@ describe("calcite-shell-panel", () => {
 
     const element = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
 
-    expect(await element.isVisible()).toBe(true);
+    const isVisible = await element.isVisible();
+
+    expect(isVisible).toBe(true);
   });
 
   it("collapsed property should hide panel content", async () => {
@@ -53,7 +55,9 @@ describe("calcite-shell-panel", () => {
 
     const element = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
 
-    expect(element).toBeNull();
+    const isVisible = await element.isVisible();
+
+    expect(isVisible).toBe(false);
   });
 
   it("leading layout property should have action slot first ", async () => {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -20,3 +20,7 @@ $shell-panel-max-width: 360px !default;
   height: 100%;
   overflow: auto;
 }
+
+.content[hidden] {
+  display: none;
+}

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -35,11 +35,11 @@ export class CalciteShellPanel {
   render() {
     const { collapsed, layout } = this;
 
-    const contentNode = !collapsed ? (
-      <div class={CSS.content}>
+    const contentNode = (
+      <div class={CSS.content} hidden={collapsed}>
         <slot />
       </div>
-    ) : null;
+    );
 
     const actionBarNode = <slot name="action-bar" />;
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -17,6 +17,11 @@ export class CalciteShellPanel {
   // --------------------------------------------------------------------------
 
   /**
+   * Hide the content panel.
+   */
+  @Prop({ reflect: true }) collapsed = false;
+
+  /**
    * Arrangement of the component.
    */
   @Prop({ reflect: true }) layout: CalciteLayout = "leading";
@@ -28,13 +33,13 @@ export class CalciteShellPanel {
   // --------------------------------------------------------------------------
 
   render() {
-    const { layout } = this;
+    const { collapsed, layout } = this;
 
-    const contentNode = (
+    const contentNode = !collapsed ? (
       <div class={CSS.content}>
         <slot />
       </div>
-    );
+    ) : null;
 
     const actionBarNode = <slot name="action-bar" />;
 


### PR DESCRIPTION
**Related Issue:** #164 

## Summary

add collapsed property to hide shell panel content

<!--
If this is component-related, please verify that:

- [x] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [x] changes have been tested with demo page in Edge
-->
