### PR TITLE
Issue #177: Reference partials by exact name to ensure rebuild.

### DIFF
--- a/src/assets/styles/includes.scss
+++ b/src/assets/styles/includes.scss
@@ -1,7 +1,7 @@
 @import "./node_modules/@esri/calcite-colors/colors.scss";
 @import "./node_modules/@esri/calcite-base/dist/variables";
-@import "./type";
-@import "./layout";
-@import "./color";
-@import "./animation";
-@import "./base";
+@import "./_type";
+@import "./_layout";
+@import "./_color";
+@import "./_animation";
+@import "./_base";


### PR DESCRIPTION
**Related Issue:** #177 

## Summary

Using exact file names for partials plays better with Stencil's watch mode. ~I'll create a separate Stencil bug for this since dropping the underscore in partials is a common Sass pattern.~ Possibly related to https://github.com/ionic-team/stencil-sass/issues/8.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
