### PR TITLE
Issue #182: Use different component namespace for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ npm install --save @esri/calcite-app-components
 `calcite-app-components` can be loaded via two `<script>` tags in the head of your HTML document:
 
 ```html
-<script type="module" src="<path-to-calcite-app-components-package>/dist/calcite/calcite.esm.js"></script>
-<script nomodule="" src="<path-to-calcite-app-components-package>/dist/calcite/calcite.js"></script>
+<script type="module" src="<path-to-calcite-app-components-package>/dist/calcite-app/calcite-app.esm.js"></script>
+<script nomodule="" src="<path-to-calcite-app-components-package>/dist/calcite-app/calcite-app.js"></script>
 ```
 
 Browsers that support modules will load the first, while older browsers will load the second, bundled version. It's worth noting that only components that are actually used will be loaded.
@@ -40,10 +40,7 @@ Browsers that support modules will load the first, while older browsers will loa
 You will also need to add a `<link>` tag for the shared component styles:
 
 ```html
-<link
-  rel="stylesheet"
-  href="<path-to-calcite-app-components-package>/dist/calcite/calcite.esm.js/dist/calcite/calcite.css"
-/>
+<link rel="stylesheet" href="<path-to-calcite-app-components-package>/dist/calcite-app/calcite-app.css" />
 ```
 
 Once these tags are added, components can be used just like any other HTML element.
@@ -74,7 +71,7 @@ module.exports = {
 Lastly, add the import in your main bundle js (or ts) file:
 
 ```
-import '@esri/calcite-app-components/dist/calcite.js';
+import '@esri/calcite-app-components/dist/calcite-app.js';
 ```
 
 This will add the initial Stencil loader to your bundle, and copy over the actual component code to the output directory you've configured for Webpack. Components will still be lazy-loaded as they are needed. _Note:_ you must use the `.js` file path for the Webpack plugin to work correctly, even if your bundle file is a TypeScript file.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
   "jsnext:main": "dist/esm/index.mjs",
-  "unpkg": "dist/calcite.js",
+  "unpkg": "dist/calcite-app.js",
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -22,7 +22,7 @@
   }
 
   loadCss("demos/demos.css");
-  loadCss("build/calcite.css");
-  loadScript("build/calcite.esm.js", { type: "module" });
-  loadScript("build/calcite.js", { noModule: true });
+  loadCss("build/calcite-app.css");
+  loadScript("build/calcite-app.esm.js", { type: "module" });
+  loadScript("build/calcite-app.js", { noModule: true });
 })();

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -4,7 +4,7 @@ import { sass } from "@stencil/sass";
 import autoprefixer from "autoprefixer";
 
 export const config: Config = {
-  namespace: "calcite",
+  namespace: "calcite-app",
   bundles: [
     {
       components: ["calcite-action", "calcite-action-group", "calcite-action-bar", "calcite-action-pad"]

--- a/stencil.docs.config.ts
+++ b/stencil.docs.config.ts
@@ -4,7 +4,7 @@ import { sass } from "@stencil/sass";
 import autoprefixer from "autoprefixer";
 
 export const config: Config = {
-  namespace: "calcite",
+  namespace: "calcite-app",
   outputTargets: [
     {
       type: "www",


### PR DESCRIPTION
**Related Issue:** #182 

## Summary

The shared `calcite` namespace was causing issues when both component libs were being used side-by-side.

**Note**: this does not change the component or event namespaces.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
