### PR TITLE
Component positioning & RTL fixes

### DIFF
--- a/src/components/calcite-action-pad/calcite-action-pad.scss
+++ b/src/components/calcite-action-pad/calcite-action-pad.scss
@@ -1,4 +1,8 @@
-:host {
+:host([hidden]) {
+  display: none;
+}
+
+.container {
   background-color: var(--calcite-app-background);
   display: flex;
   color: var(--calcite-app-foreground);
@@ -10,20 +14,68 @@
   animation: calcite-app-fade-in var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function);
 }
 
-:host([hidden]) {
-  display: none;
-}
-
-:host([position-type="side"]) {
+:host([position-type="side"]) .container--leading {
   left: 100%;
 }
 
-:host([position-type="over"]) {
+:host([position-type="side"]) .container--leading.calcite--rtl {
+  left: unset;
+  right: 100%;
+}
+
+:host([position-type="side"]) .container--trailing {
+  right: 100%;
+}
+
+:host([position-type="side"]) .container--trailing.calcite--rtl {
+  right: unset;
+  left: 100%;
+}
+
+:host([position-type="over"]) .container--leading {
   left: 50%;
   margin-left: -21px;
 }
 
-:host([position-type="anchor"]) {
+:host([position-type="over"]) .container--leading.calcite--rtl {
+  left: unset;
+  margin-left: unset;
+  right: 50%;
+  margin-right: -21px;
+}
+
+:host([position-type="over"]) .container--trailing {
+  right: 50%;
+  margin-right: -21px;
+}
+
+:host([position-type="over"]) .container--trailing.calcite--rtl {
+  right: unset;
+  margin-right: unset;
+  left: 50%;
+  margin-left: -21px;
+}
+
+:host([position-type="anchor"]) .container--leading {
+  left: 50%;
+  margin-left: -21px;
+}
+
+:host([position-type="anchor"]) .container--leading.calcite--rtl {
+  left: unset;
+  margin-left: unset;
+  right: 50%;
+  margin-right: -21px;
+}
+
+:host([position-type="anchor"]) .container--trailing {
+  right: 50%;
+  margin-right: -21px;
+}
+
+:host([position-type="anchor"]) .container--trailing.calcite--rtl {
+  right: unset;
+  margin-right: unset;
   left: 50%;
   margin-left: -21px;
 }

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -4,6 +4,14 @@ import { CalcitePlacement, CalciteTheme } from "../interfaces";
 
 import { getOffsetTop } from "../utils/position";
 
+import { CSS } from "./resources";
+
+import classnames from "classnames";
+
+import { getElementDir } from "calcite-components/dist/collection/utils/dom";
+
+import { CSS_UTILITY } from "../utils/resources";
+
 @Component({
   tag: "calcite-action-pad",
   styleUrl: "calcite-action-pad.scss",
@@ -51,15 +59,29 @@ export class CalciteActionPad {
   // --------------------------------------------------------------------------
 
   render() {
-    const { offsetTop } = this;
+    const { el, offsetTop } = this;
 
     const style = {
       top: `${offsetTop}px`
     };
 
+    const rtl = getElementDir(el) === "rtl";
+
+    const closest = el.closest("calcite-shell-panel");
+    const layout = (closest && closest.layout) || "leading";
+
     return (
-      <Host style={style}>
-        <slot />
+      <Host>
+        <div
+          style={style}
+          class={classnames(CSS.container, {
+            [CSS_UTILITY.rtl]: rtl,
+            [CSS.containerLeading]: layout === "leading",
+            [CSS.containerTrailing]: layout === "trailing"
+          })}
+        >
+          <slot />
+        </div>
       </Host>
     );
   }

--- a/src/components/calcite-action-pad/resources.ts
+++ b/src/components/calcite-action-pad/resources.ts
@@ -1,0 +1,5 @@
+export const CSS = {
+  container: "container",
+  containerLeading: "container--leading",
+  containerTrailing: "container--trailing"
+};

--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -18,18 +18,6 @@
   position: relative;
 }
 
-.chevron-right {
-  display: none;
-}
-
-.calcite--rtl .chevron-left {
-  display: none;
-}
-
-.calcite--rtl .chevron-right {
-  display: block;
-}
-
 .header {
   align-items: center;
   color: var(--calcite-app-foreground);

--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -18,6 +18,18 @@
   position: relative;
 }
 
+.chevron-right {
+  display: none;
+}
+
+.calcite--rtl .chevron-left {
+  display: none;
+}
+
+.calcite--rtl .chevron-right {
+  display: block;
+}
+
 .header {
   align-items: center;
   color: var(--calcite-app-foreground);
@@ -79,6 +91,11 @@ h2.heading {
   border: 1px solid var(--calcite-app-border);
   animation: calcite-app-fade-in-down var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function);
   display: none;
+}
+
+.calcite--rtl .menu {
+  left: var(--calcite-app-menu-offset);
+  right: auto;
 }
 
 .menu--open {

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
+import { Component, Element, Event, EventEmitter, Host, Prop, State, h } from "@stencil/core";
 
 import { chevronLeft16, chevronRight16, ellipsis16 } from "@esri/calcite-ui-icons";
 
@@ -68,6 +68,8 @@ export class CalciteFlowItem {
 
   @Element() el: HTMLElement;
 
+  @State() rtl: boolean = getElementDir(this.el) === "rtl";
+
   // --------------------------------------------------------------------------
   //
   //  Events
@@ -101,7 +103,9 @@ export class CalciteFlowItem {
   // --------------------------------------------------------------------------
 
   renderBackButton() {
-    const { showBackButton, textBack } = this;
+    const { rtl, showBackButton, textBack } = this;
+
+    const path = rtl ? chevronRight16 : chevronLeft16;
 
     return showBackButton ? (
       <calcite-action
@@ -111,8 +115,7 @@ export class CalciteFlowItem {
         class={CSS.backButton}
         onClick={this.backButtonClick}
       >
-        <CalciteIcon svgAttributes={{ class: CSS.chevronLeft }} size="16" path={chevronLeft16} />
-        <CalciteIcon svgAttributes={{ class: CSS.chevronRight }} size="16" path={chevronRight16} />
+        <CalciteIcon size="16" path={path} />
       </calcite-action>
     ) : null;
   }
@@ -202,13 +205,11 @@ export class CalciteFlowItem {
       </section>
     );
 
-    const rtl = getElementDir(this.el) === "rtl";
-
     return (
       <Host>
         <article
           class={classnames(CSS.container, {
-            [CSS_UTILITY.rtl]: rtl
+            [CSS_UTILITY.rtl]: this.rtl
           })}
         >
           {headerNode}

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -1,6 +1,8 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
 
-import { chevronLeft16, ellipsis16 } from "@esri/calcite-ui-icons";
+import { chevronLeft16, chevronRight16, ellipsis16 } from "@esri/calcite-ui-icons";
+
+import { getElementDir } from "calcite-components/dist/collection/utils/dom";
 
 import classnames from "classnames";
 
@@ -8,6 +10,8 @@ import { CSS, TEXT } from "./resources";
 import CalciteIcon from "../utils/CalciteIcon";
 
 import { CalciteTheme } from "../interfaces";
+
+import { CSS_UTILITY } from "../utils/resources";
 
 @Component({
   tag: "calcite-flow-item",
@@ -107,7 +111,8 @@ export class CalciteFlowItem {
         class={CSS.backButton}
         onClick={this.backButtonClick}
       >
-        <CalciteIcon size="16" path={chevronLeft16} />
+        <CalciteIcon svgAttributes={{ class: CSS.chevronLeft }} size="16" path={chevronLeft16} />
+        <CalciteIcon svgAttributes={{ class: CSS.chevronRight }} size="16" path={chevronRight16} />
       </calcite-action>
     ) : null;
   }
@@ -197,9 +202,15 @@ export class CalciteFlowItem {
       </section>
     );
 
+    const rtl = getElementDir(this.el) === "rtl";
+
     return (
       <Host>
-        <article class={CSS.container}>
+        <article
+          class={classnames(CSS.container, {
+            [CSS_UTILITY.rtl]: rtl
+          })}
+        >
           {headerNode}
           {contentContainerNode}
           {this.renderFooterActions()}

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -68,8 +68,6 @@ export class CalciteFlowItem {
 
   @Element() el: HTMLElement;
 
-  rtl = false;
-
   // --------------------------------------------------------------------------
   //
   //  Events
@@ -102,8 +100,8 @@ export class CalciteFlowItem {
   //
   // --------------------------------------------------------------------------
 
-  renderBackButton() {
-    const { rtl, showBackButton, textBack } = this;
+  renderBackButton(rtl: boolean) {
+    const { showBackButton, textBack } = this;
 
     const path = rtl ? chevronRight16 : chevronLeft16;
 
@@ -190,7 +188,6 @@ export class CalciteFlowItem {
     const { el, showBackButton, heading } = this;
 
     const rtl = getElementDir(el) === "rtl";
-    this.rtl = rtl;
 
     const headingClasses = {
       [CSS.heading]: true,
@@ -199,7 +196,7 @@ export class CalciteFlowItem {
 
     const headerNode = (
       <header class={CSS.header}>
-        {this.renderBackButton()}
+        {this.renderBackButton(rtl)}
         <h2 class={classnames(headingClasses)}>{heading}</h2>
         {this.renderHeaderActions()}
       </header>

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Host, Prop, State, h } from "@stencil/core";
+import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
 
 import { chevronLeft16, chevronRight16, ellipsis16 } from "@esri/calcite-ui-icons";
 
@@ -68,7 +68,7 @@ export class CalciteFlowItem {
 
   @Element() el: HTMLElement;
 
-  @State() rtl: boolean = getElementDir(this.el) === "rtl";
+  rtl = false;
 
   // --------------------------------------------------------------------------
   //
@@ -187,14 +187,20 @@ export class CalciteFlowItem {
   }
 
   render() {
+    const { el, showBackButton, heading } = this;
+
+    const rtl = getElementDir(el) === "rtl";
+    this.rtl = rtl;
+
     const headingClasses = {
       [CSS.heading]: true,
-      [CSS.headingFirst]: !this.showBackButton
+      [CSS.headingFirst]: !showBackButton
     };
+
     const headerNode = (
       <header class={CSS.header}>
         {this.renderBackButton()}
-        <h2 class={classnames(headingClasses)}>{this.heading}</h2>
+        <h2 class={classnames(headingClasses)}>{heading}</h2>
         {this.renderHeaderActions()}
       </header>
     );
@@ -209,7 +215,7 @@ export class CalciteFlowItem {
       <Host>
         <article
           class={classnames(CSS.container, {
-            [CSS_UTILITY.rtl]: this.rtl
+            [CSS_UTILITY.rtl]: rtl
           })}
         >
           {headerNode}

--- a/src/components/calcite-flow-item/resources.ts
+++ b/src/components/calcite-flow-item/resources.ts
@@ -4,8 +4,6 @@ export const CSS = {
   heading: "heading",
   headingFirst: "heading--first",
   backButton: "back-button",
-  chevronLeft: "chevron-left",
-  chevronRight: "chevron-right",
   singleActionContainer: "single-action-container",
   menuContainer: "menu-container",
   menuButton: "menu-button",

--- a/src/components/calcite-flow-item/resources.ts
+++ b/src/components/calcite-flow-item/resources.ts
@@ -4,6 +4,8 @@ export const CSS = {
   heading: "heading",
   headingFirst: "heading--first",
   backButton: "back-button",
+  chevronLeft: "chevron-left",
+  chevronRight: "chevron-right",
   singleActionContainer: "single-action-container",
   menuContainer: "menu-container",
   menuButton: "menu-button",

--- a/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.scss
+++ b/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.scss
@@ -12,14 +12,22 @@
   animation: calcite-app-fade-in-scale var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function);
 }
 
-// todo: RTL
-
 :host([position-type="side"]) .container--leading {
   left: 100%;
 }
 
+:host([position-type="side"]) .container--leading.calcite--rtl {
+  left: unset;
+  right: 100%;
+}
+
 :host([position-type="side"]) .container--trailing {
   right: 100%;
+}
+
+:host([position-type="side"]) .container--trailing.calcite--rtl {
+  right: unset;
+  left: 100%;
 }
 
 :host([position-type="over"]) .container,
@@ -32,9 +40,21 @@
   left: 12%;
 }
 
+:host([position-type="over"]) .container--leading.calcite--rtl,
+:host([position-type="anchor"]) .container--leading.calcite--rtl {
+  left: unset;
+  right: 12%;
+}
+
 :host([position-type="over"]) .container--trailing,
 :host([position-type="anchor"]) .container--trailing {
   right: 12%;
+}
+
+:host([position-type="over"]) .container--trailing.calcite--rtl,
+:host([position-type="anchor"]) .container--trailing.calcite--rtl {
+  right: unset;
+  left: 12%;
 }
 
 .header {

--- a/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.scss
+++ b/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.scss
@@ -1,25 +1,40 @@
-:host {
-  background-color: var(--calcite-app-background);
-  color: var(--calcite-app-foreground);
+:host([hidden]) {
+  display: none;
+}
+
+.container {
   position: absolute;
   z-index: 1;
+  background-color: var(--calcite-app-background);
+  color: var(--calcite-app-foreground);
   box-shadow: var(--calcite-app-shadow-2);
   border-radius: var(--calcite-app-border-radius);
   animation: calcite-app-fade-in-scale var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function);
 }
 
-:host([hidden]) {
-  display: none;
-}
+// todo: RTL
 
-:host([position-type="side"]) {
+:host([position-type="side"]) .container--leading {
   left: 100%;
 }
 
-:host([position-type="over"]),
-:host([position-type="anchor"]) {
-  left: 12%;
+:host([position-type="side"]) .container--trailing {
+  right: 100%;
+}
+
+:host([position-type="over"]) .container,
+:host([position-type="anchor"]) .container {
   width: 89%;
+}
+
+:host([position-type="over"]) .container--leading,
+:host([position-type="anchor"]) .container--leading {
+  left: 12%;
+}
+
+:host([position-type="over"]) .container--trailing,
+:host([position-type="anchor"]) .container--trailing {
+  right: 12%;
 }
 
 .header {

--- a/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.tsx
+++ b/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.tsx
@@ -22,6 +22,10 @@ import { CSS } from "./resources";
 
 import classnames from "classnames";
 
+import { getElementDir } from "calcite-components/dist/collection/utils/dom";
+
+import { CSS_UTILITY } from "../utils/resources";
+
 @Component({
   tag: "calcite-shell-floating-panel",
   styleUrl: "calcite-shell-floating-panel.scss",
@@ -109,19 +113,22 @@ export class CalciteShellFloatingPanel {
   // --------------------------------------------------------------------------
 
   render() {
-    const { offsetTop } = this;
+    const { offsetTop, el } = this;
 
     const style = {
       top: `${offsetTop}px`
     };
 
-    const closest = this.el.closest("calcite-shell-panel");
+    const closest = el.closest("calcite-shell-panel");
     const layout = (closest && closest.layout) || "leading";
+
+    const rtl = getElementDir(el) === "rtl";
 
     return (
       <Host>
         <div
           class={classnames(CSS.container, {
+            [CSS_UTILITY.rtl]: rtl,
             [CSS.containerLeading]: layout === "leading",
             [CSS.containerTrailing]: layout === "trailing"
           })}

--- a/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.tsx
+++ b/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.tsx
@@ -20,6 +20,8 @@ import CalciteIcon from "../utils/CalciteIcon";
 
 import { CSS } from "./resources";
 
+import classnames from "classnames";
+
 @Component({
   tag: "calcite-shell-floating-panel",
   styleUrl: "calcite-shell-floating-panel.scss",
@@ -113,16 +115,27 @@ export class CalciteShellFloatingPanel {
       top: `${offsetTop}px`
     };
 
+    const closest = this.el.closest("calcite-shell-panel");
+    const layout = (closest && closest.layout) || "leading";
+
     return (
-      <Host style={style}>
-        <header class={CSS.header}>
-          <h3 class={CSS.heading}>{this.heading}</h3>
-          <calcite-action onClick={this.hidePanel}>
-            <CalciteIcon size="16" path={x16} />
-          </calcite-action>
-        </header>
-        <div class={CSS.content}>
-          <slot />
+      <Host>
+        <div
+          class={classnames(CSS.container, {
+            [CSS.containerLeading]: layout === "leading",
+            [CSS.containerTrailing]: layout === "trailing"
+          })}
+          style={style}
+        >
+          <header class={CSS.header}>
+            <h3 class={CSS.heading}>{this.heading}</h3>
+            <calcite-action onClick={this.hidePanel}>
+              <CalciteIcon size="16" path={x16} />
+            </calcite-action>
+          </header>
+          <div class={CSS.content}>
+            <slot />
+          </div>
         </div>
       </Host>
     );

--- a/src/components/calcite-shell-floating-panel/resources.ts
+++ b/src/components/calcite-shell-floating-panel/resources.ts
@@ -1,4 +1,7 @@
 export const CSS = {
+  container: "container",
+  containerLeading: "container--leading",
+  containerTrailing: "container--trailing",
   header: "header",
   heading: "heading",
   content: "content"

--- a/src/demos/calcite-shell-rtl.html
+++ b/src/demos/calcite-shell-rtl.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="rtl">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />

--- a/src/demos/calcite-shell-rtl.html
+++ b/src/demos/calcite-shell-rtl.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="rtl">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
@@ -76,7 +76,7 @@
         </script>
 
         <h2>Light Theme</h2>
-        <div id="light_theme_container" class="calcite-shell-container">
+        <div id="light_theme_container" class="calcite-shell-container" dir="rtl">
           <calcite-shell>
             <calcite-shell-panel slot="primary-panel" layout="leading">
               <calcite-shell-floating-panel
@@ -324,7 +324,7 @@
 
         <h2>Dark Theme</h2>
 
-        <div class="calcite-shell-container">
+        <div class="calcite-shell-container" dir="rtl">
           <calcite-shell theme="dark">
             <calcite-shell-panel slot="primary-panel" layout="leading">
               <calcite-shell-floating-panel

--- a/src/demos/calcite-shell.html
+++ b/src/demos/calcite-shell.html
@@ -68,7 +68,7 @@
         </script>
 
         <h2>Light Theme</h2>
-        <div class="calcite-shell-container">
+        <div class="calcite-shell-container" dir="rtl">
           <calcite-shell>
             <calcite-shell-panel slot="primary-panel" layout="leading">
               <calcite-shell-floating-panel

--- a/src/demos/calcite-shell.html
+++ b/src/demos/calcite-shell.html
@@ -20,12 +20,7 @@
     <main>
       <div class="example-container">
         <h1>calcite-shell</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell/readme.md"
-            >calcite-shell readme.</a
-          >
-        </p>
+        <p>see the <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell/readme.md">calcite-shell readme.</a></p>
 
         <style>
           .calcite-shell-container {
@@ -37,9 +32,6 @@
             margin: 0 auto;
             box-shadow: 0 2px 16px rgba(0, 0, 0, 0.2);
             position: relative;
-          }
-          .button {
-            margin: 20px;
           }
         </style>
 
@@ -76,7 +68,7 @@
         </script>
 
         <h2>Light Theme</h2>
-        <div id="light_theme_container" class="calcite-shell-container">
+        <div class="calcite-shell-container">
           <calcite-shell>
             <calcite-shell-panel slot="primary-panel" layout="leading">
               <calcite-shell-floating-panel

--- a/src/demos/calcite-shell.html
+++ b/src/demos/calcite-shell.html
@@ -20,7 +20,12 @@
     <main>
       <div class="example-container">
         <h1>calcite-shell</h1>
-        <p>see the <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell/readme.md">calcite-shell readme.</a></p>
+        <p>
+          see the
+          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell/readme.md"
+            >calcite-shell readme.</a
+          >
+        </p>
 
         <style>
           .calcite-shell-container {
@@ -32,6 +37,9 @@
             margin: 0 auto;
             box-shadow: 0 2px 16px rgba(0, 0, 0, 0.2);
             position: relative;
+          }
+          .button {
+            margin: 20px;
           }
         </style>
 
@@ -68,7 +76,7 @@
         </script>
 
         <h2>Light Theme</h2>
-        <div class="calcite-shell-container" dir="rtl">
+        <div id="light_theme_container" class="calcite-shell-container">
           <calcite-shell>
             <calcite-shell-panel slot="primary-panel" layout="leading">
               <calcite-shell-floating-panel
@@ -313,6 +321,8 @@
             <footer slot="shell-footer">Footer</footer>
           </calcite-shell>
         </div>
+
+        <button class="button" id="toggle_rtl">Toggle RTL</button>
 
         <h2>Dark Theme</h2>
 
@@ -562,6 +572,19 @@
       </div>
       <p style="text-align: center;">Box Shadow added to show app edges.</p>
       <script>
+        var toggle_rtl = document.getElementById("toggle_rtl");
+        toggle_rtl &&
+          toggle_rtl.addEventListener("click", function() {
+            var light_theme_container = document.getElementById("light_theme_container");
+            if (!light_theme_container) {
+              return;
+            }
+
+            var rtl = light_theme_container.getAttribute("dir") === "rtl";
+
+            light_theme_container.setAttribute("dir", rtl ? "ltr" : "rtl");
+          });
+
         var actionPad = document.getElementById("action-pad");
         var actionPadButton = document.getElementById("action-pad-button");
         actionPadButton.addEventListener("click", function() {


### PR DESCRIPTION
**Related Issue:** #185

## Summary

- Adds positioning fixes for the floating panel and action pad
  - positioning depends on shell panel leading/trailing value
  - adds RTL support
- Fixes rtl support for `calcite-flow-item` menu
- Adds shell demo file for RTL 


<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->


Bug: calcite-floating-panel appears on wrong side #185

@jcfranco @asangma  can we make this higher priority? @AdelheidF needs this fix to continue work.
