### PR TITLE
[!mergeable] Issue #159: Add control slot to <calcite-block-section>.

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.e2e.ts
+++ b/src/components/calcite-block-section/calcite-block-section.e2e.ts
@@ -58,7 +58,7 @@ describe("calcite-block-section", () => {
     await page.setContent("<calcite-block-section></calcite-block-section>");
     const element = await page.find("calcite-block-section");
     const toggleSpy = await element.spyOnEvent("calciteBlockSectionToggle");
-    const toggle = await page.find(`calcite-block-section >>> calcite-action`);
+    const toggle = await page.find(`calcite-block-section >>> .${CSS.toggle}`);
 
     expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
 
@@ -81,7 +81,26 @@ describe("calcite-block-section", () => {
       <calcite-block-section text="test text" open="true"></calcite-block-section>
     `);
 
-    const element = await page.find(`calcite-block-section >>> calcite-action`);
-    expect(await element.getProperty("text")).toBe("test text");
+    const element = await page.find(`calcite-block-section >>> .${CSS.heading}`);
+    expect(element.innerText).toBe("test text");
+  });
+
+  it("supports a nested control", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-block-section heading="test-heading" collapsible><input class="nested-control" slot="control" /></calcite-block-section>`
+    );
+    const element = await page.find("calcite-block-section");
+    const elementToggleSpy = await element.spyOnEvent("calciteBlockSectionToggle");
+
+    const control = await element.find(".nested-control");
+    expect(await control.isVisible()).toBe(true);
+
+    await control.click();
+    expect(elementToggleSpy).toHaveReceivedEventTimes(0);
+
+    await element.click();
+    await element.click();
+    expect(elementToggleSpy).toHaveReceivedEventTimes(2);
   });
 });

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -1,5 +1,34 @@
+$header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
+
 :host {
   display: block;
+}
+
+.header-container {
+  background-color: var(--calcite-app-background);
+}
+
+.header {
+  flex-grow: 1;
+}
+
+.toggle {
+  padding: $header-content-padding;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+  margin: 0;
+  text-align: unset;
+  width: 100%;
+}
+
+.toggle-icon {
+  margin: 0 4px;
+  fill: var(--calcite-app-foreground);
 }
 
 .content {

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -5,6 +5,8 @@ import { getElementDir } from "../utils/dom";
 import { CSS, TEXT } from "./resources";
 import CalciteIcon from "../utils/CalciteIcon";
 
+const CONTROL_SLOT_NAME = "control";
+
 @Component({
   tag: "calcite-block-section",
   styleUrl: "calcite-block-section.scss",
@@ -68,7 +70,18 @@ export class CalciteBlockSection {
   //
   // --------------------------------------------------------------------------
 
-  onHeaderClick = () => {
+  onHeaderClick = (event: MouseEvent) => {
+    const controlSlot = this.el.shadowRoot.querySelector<HTMLSlotElement>(
+      `slot[name=${CONTROL_SLOT_NAME}]`
+    );
+    const control = controlSlot && controlSlot.assignedNodes()[0];
+
+    if (control && control.contains(event.target as Node)) {
+      event.stopPropagation();
+      event.preventDefault();
+      return;
+    }
+
     this.open = !this.open;
     this.calciteBlockSectionToggle.emit();
   };
@@ -80,21 +93,30 @@ export class CalciteBlockSection {
   // --------------------------------------------------------------------------
 
   render() {
-    const { el, open, textCollapse, textExpand } = this;
+    const { el, open, text, textCollapse, textExpand } = this;
     const dir = getElementDir(el);
     const arrowIcon = open ? caretDown16F : dir === "rtl" ? caretLeft16F : caretRight16F;
     const toggleLabel = open ? textCollapse : textExpand;
 
+    const headerContent = (
+      <header class={CSS.header}>
+        <h4 class={CSS.heading}>{text}</h4>
+        <slot name={CONTROL_SLOT_NAME} />
+      </header>
+    );
+
     const headerNode = (
-      <calcite-action
-        aria-label={toggleLabel}
-        onClick={this.onHeaderClick}
-        text={this.text}
-        text-enabled
-        compact
-      >
-        <CalciteIcon size="16" path={arrowIcon} />
-      </calcite-action>
+      <div class={CSS.headerContainer}>
+        <button
+          aria-label={toggleLabel}
+          class={CSS.toggle}
+          onClick={this.onHeaderClick}
+          title={toggleLabel}
+        >
+          <CalciteIcon size="16" path={arrowIcon} svgAttributes={{ class: CSS.toggleIcon }} />
+          {headerContent}
+        </button>
+      </div>
     );
 
     return (

--- a/src/components/calcite-block-section/resources.ts
+++ b/src/components/calcite-block-section/resources.ts
@@ -1,5 +1,11 @@
 export const CSS = {
-  content: "content"
+  content: "content",
+  headerContainer: "header-container",
+  toggle: "toggle",
+  toggleIcon: "toggle-icon",
+  heading: "heading",
+  header: "header",
+  control: "control"
 };
 
 export const TEXT = {

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -59,6 +59,15 @@
           <img alt="demo" src="https://placeimg.com/640/480/arch" />
         </calcite-block>
 
+        <h2>Header + content (section control)</h2>
+
+        <calcite-block heading="Heading" summary="summary" open collapsible>
+          <calcite-block-section text="Section 1" open>
+            <label slot="control">test <button slot="control">control</button></label>
+            <img alt="demo" src="https://placeimg.com/640/480/people" />
+          </calcite-block-section>
+        </calcite-block>
+
         <h2>RTL</h2>
 
         <calcite-block dir="rtl" heading="Heading" summary="summary" open collapsible>


### PR DESCRIPTION
**Related Issue:** #159

## Summary

Adds a control slot to `<calcite-block-section>` to support design (see issue description).

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

@asangma I removed the supporting `<calcite-action>` and reused some stuff from `<calcite-block>`. Can you help me with styling tweaks? I think the main difference is the font size and some spacing. 
