### PR TITLE
fix flow-item test intermittent errors

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
+++ b/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
@@ -124,9 +124,7 @@ it("back button / showBackButton", async () => {
 
   const eventSpy = await page.spyOnEvent("calciteFlowItemBackClick", "window");
 
-  backButtonNew.click();
-
-  await page.waitForChanges();
+  await backButtonNew.click();
 
   expect(eventSpy).toHaveReceivedEvent();
 });


### PR DESCRIPTION
**Related Issue:** none

## Summary

A minor annoyance when running the test suite - every so often the flow-item e2e tests would fail.

**File:** `src\components\calcite-flow-item\calcite-flow-item.e2e.ts`
**Line Number:** 127

This test was intermittently erroring on the above line. I suspect the `await page.waitForChanges()` wasn't properly waiting for the click to happen. So the tests suite would sometimes finish running and cleanup before that promise returned, causing the element to no longer be there by the time the click happen. Moving the await keyword in front of the click method call seems to fix this, and also makes it so we don't need `await page.waitForChanges()`

Ran the test suite like 5 times and stopped seeing this error. Seems like this fixed it.