### PR TITLE
Shell layout update

### DIFF
--- a/src/components/calcite-shell/calcite-shell.scss
+++ b/src/components/calcite-shell/calcite-shell.scss
@@ -39,8 +39,7 @@ $shell-min-height: 671px !default; // ipad + browser with tabs
   z-index: 0;
 }
 
-slot[name="primary-panel"],
-slot[name="contextual-panel"] {
+::slotted(calcite-shell-panel) {
   position: relative;
   z-index: 1;
 }

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -62,8 +62,8 @@ export class CalciteShell {
   renderMain() {
     return (
       <div class={CSS.main}>
-        {this.renderContent()}
         <slot name="primary-panel" />
+        {this.renderContent()}
         <slot name="contextual-panel" />
         <slot name="tip-manager" />
       </div>


### PR DESCRIPTION
**Related Issue:** #184

## Summary
Updated shell to make content full width and height of the …main div. Note, focus state on the esri-view is a bit weird.

 @driskull I ran e2e tests, and it all looked good. 👀 

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
