### PR TITLE
Action indicator alignment.

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -10,7 +10,7 @@
   justify-content: flex-start;
   align-items: center;
   border: none;
-  width: 100%;
+  width: auto;
   cursor: pointer;
   font-size: var(--calcite-app-font-size--1);
   line-height: normal;
@@ -45,6 +45,10 @@
   }
 }
 
+:host([text-enabled]) .button {
+  width: 100%;
+}
+
 :host([active]) .button,
 :host([active]) .button:hover {
   color: var(--calcite-app-foreground-active);
@@ -65,6 +69,10 @@
   background-color: var(--calcite-app-background-active);
 }
 
+:host([indicator][text-enabled]) .button {
+  padding-right: var(--calcite-app-side-spacing);
+}
+
 :host([indicator]) .button::after {
   content: "";
   border-radius: 50%;
@@ -81,6 +89,11 @@
 :host([indicator]) .calcite--rtl::after {
   right: unset;
   left: var(--calcite-app-side-spacing-quarter);
+}
+
+:host([indicator][text-enabled]) .calcite--rtl {
+  padding-right: var(--calcite-app-side-spacing-three-quarters);
+  padding-left: var(--calcite-app-side-spacing);
 }
 
 :host([indicator]) .button:hover::after {


### PR DESCRIPTION
**Related Issue:** #187

## Summary
Set button width to auto when not text-enabled.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
