### PR TITLE
Issue #207: Add common test util

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.e2e.ts
+++ b/src/components/calcite-block-section/calcite-block-section.e2e.ts
@@ -1,32 +1,19 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS, TEXT } from "./resources";
+import { hidden, reflects, renders } from "../../tests/commonTests";
 
 describe("calcite-block-section", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-block-section"));
 
-    await page.setContent("<calcite-block-section></calcite-block-section>");
-    const element = await page.find("calcite-block-section");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-block-section"));
 
-  it("open property is reflected", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-block-section></calcite-block-section>");
-    let element = await page.find("calcite-block-section");
-
-    element.setProperty("open", true);
-    await page.waitForChanges();
-
-    element = await page.find("calcite-block-section[open]");
-    expect(element).toBeTruthy();
-
-    element.setProperty("open", false);
-    await page.waitForChanges();
-
-    element = await page.find("calcite-block-section[open]");
-    expect(element).toBeNull();
-  });
+  it("reflects properties", async () =>
+    reflects("calcite-block-section", [
+      {
+        propertyName: "open",
+        value: true
+      }
+    ]));
 
   it("can display/hide content", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -1,26 +1,23 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS, TEXT } from "./resources";
+import { defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-block", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-block></calcite-block>");
-    const element = await page.find("calcite-block");
+  it("renders", async () => renders("calcite-block"));
 
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-block"));
 
-  it("defaults", async () => {
-    const page = await newE2EPage();
-    await page.setContent("<calcite-block></calcite-block>");
-    const element = await page.find("calcite-block");
-
-    const collapsibleProp = await element.getProperty("collapsible");
-    expect(collapsibleProp).toBe(false);
-
-    const openProp = await element.getProperty("open");
-    expect(openProp).toBe(false);
-  });
+  it("has property defaults", async () =>
+    defaults("calcite-block", [
+      {
+        propertyName: "collapsible",
+        defaultValue: false
+      },
+      {
+        propertyName: "open",
+        defaultValue: false
+      }
+    ]));
 
   it("can display/hide content", async () => {
     const page = await newE2EPage();

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -1,0 +1,76 @@
+import { newE2EPage } from "@stencil/core/testing";
+import * as pd from "@stencil/core/dist/testing/puppeteer/puppeteer-declarations";
+
+async function simplePageSetup(componentTag: string): Promise<pd.E2EPage> {
+  const page = await newE2EPage();
+  await page.setContent(`<${componentTag}><${componentTag}/>`);
+  return page;
+}
+
+export async function renders(componentTag: string): Promise<void> {
+  const page = await simplePageSetup(componentTag);
+  const element = await page.find(componentTag);
+
+  expect(element).toHaveClass("hydrated");
+  expect(await element.isVisible()).toBe(true);
+}
+
+export async function reflects(
+  componentTag: string,
+  propsToTest: {
+    propertyName: string;
+    value: any;
+  }[]
+): Promise<void> {
+  const page = await simplePageSetup(componentTag);
+  const element = await page.find(componentTag);
+
+  for (const propAndValue of propsToTest) {
+    const { propertyName, value } = propAndValue;
+    const componentAttributeSelector = `${componentTag}[${propertyName}]`;
+
+    element.setProperty(propertyName, value);
+    await page.waitForChanges();
+
+    expect(await page.find(componentAttributeSelector)).toBeTruthy();
+
+    if (typeof value === "boolean") {
+      element.setProperty(propertyName, !value);
+      await page.waitForChanges();
+
+      expect(await page.find(componentAttributeSelector)).toBeNull();
+
+      element.setProperty(propertyName, value);
+      await page.waitForChanges();
+
+      expect(await page.find(componentAttributeSelector)).toBeTruthy();
+    }
+  }
+}
+
+export async function defaults(
+  componentTag: string,
+  propsToTest: {
+    propertyName: string;
+    defaultValue: any;
+  }[]
+): Promise<void> {
+  const page = await simplePageSetup(componentTag);
+  const element = await page.find(componentTag);
+
+  for (const propAndValue of propsToTest) {
+    const { propertyName, defaultValue } = propAndValue;
+    const prop = await element.getProperty(propertyName);
+    expect(prop).toBe(defaultValue);
+  }
+}
+
+export async function hidden(componentTag: string): Promise<void> {
+  const page = await simplePageSetup(componentTag);
+  const element = await page.find(componentTag);
+
+  element.setAttribute("hidden", "");
+  await page.waitForChanges();
+
+  expect(await element.isVisible()).toBe(false);
+}


### PR DESCRIPTION
**Related Issue:** #207

## Summary

This adds common tests helpers to reduce boilerplate for common tests across components. This initially updates `calcite-block` components, but will submit follow-up PRs for other components to minimize conflicts.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
