### PR TITLE
Issue #207: Update other E2E tests to use utility.

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -1,13 +1,10 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-action-bar", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-action-bar"));
 
-    await page.setContent("<calcite-action-bar></calcite-action-bar>");
-    const element = await page.find("calcite-action-bar");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-action-bar"));
 
   it("defaults", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-action-group/calcite-action-group.e2e.ts
+++ b/src/components/calcite-action-group/calcite-action-group.e2e.ts
@@ -1,11 +1,7 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-action-group", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-action-group"));
 
-    await page.setContent("<calcite-action-group></calcite-action-group>");
-    const element = await page.find("calcite-action-group");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-action-group"));
 });

--- a/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
@@ -1,13 +1,10 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-action-pad", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-action-pad"));
 
-    await page.setContent("<calcite-action-pad></calcite-action-pad>");
-    const element = await page.find("calcite-action-pad");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-action-pad"));
 
   it("position defaults", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-action/calcite-action.e2e.ts
+++ b/src/components/calcite-action/calcite-action.e2e.ts
@@ -1,13 +1,10 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-action", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-action"));
 
-    await page.setContent("<calcite-action></calcite-action>");
-    const element = await page.find("calcite-action");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-action"));
 
   it("should not have text container", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-example/calcite-example.e2e.ts
+++ b/src/components/calcite-example/calcite-example.e2e.ts
@@ -1,13 +1,16 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS, TEXT } from "./resources";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe.skip("calcite-example", () => {
-  it("renders and shows myString by default", async () => {
+  it("renders", async () => renders("calcite-example"));
+
+  it("honors hidden attribute", async () => hidden("calcite-example"));
+
+  it("shows myString by default", async () => {
     const page = await newE2EPage();
 
     await page.setContent("<calcite-example></calcite-example>");
-    const element = await page.find("calcite-example");
-    expect(element).toHaveClass("hydrated");
 
     const div = await page.find(`calcite-example >>> .${CSS.foo}`);
     expect(div.innerText).toBe(TEXT.myString);

--- a/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
+++ b/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
@@ -1,15 +1,12 @@
 import { newE2EPage } from "@stencil/core/testing";
 
 import { CSS, TEXT } from "./resources";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-flow-item", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-flow-item"));
 
-    await page.setContent("<calcite-flow-item></calcite-flow-item>");
-    const element = await page.find("calcite-flow-item");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-flow-item"));
 
   it("should not render containers when there are no menu actions", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-flow/calcite-flow.e2e.ts
+++ b/src/components/calcite-flow/calcite-flow.e2e.ts
@@ -1,17 +1,12 @@
 import { newE2EPage } from "@stencil/core/testing";
 
 import { CSS } from "./resources";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-flow", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-flow"));
 
-    await page.setContent("<calcite-flow></calcite-flow>");
-
-    const element = await page.find("calcite-flow");
-
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-flow"));
 
   it("frame defaults", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.e2e.ts
+++ b/src/components/calcite-shell-floating-panel/calcite-shell-floating-panel.e2e.ts
@@ -1,13 +1,10 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-shell-floating-panel", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-shell-floating-panel"));
 
-    await page.setContent("<calcite-shell-floating-panel></calcite-shell-floating-panel>");
-    const element = await page.find("calcite-shell-floating-panel");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-shell-floating-panel"));
 
   it("position defaults", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -1,30 +1,30 @@
 import { newE2EPage } from "@stencil/core/testing";
 
 import { CSS } from "./resources";
+import { defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-shell-panel", () => {
-  it("renders", async () => {
+  it("renders", async () => renders("calcite-shell-panel"));
+
+  it("honors hidden attribute", async () => hidden("calcite-shell-panel"));
+
+  it("defaults", async () =>
+    defaults("calcite-shell-panel", [
+      {
+        propertyName: "layout",
+        defaultValue: "leading"
+      },
+      {
+        propertyName: "collapsed",
+        defaultValue: false
+      }
+    ]));
+
+  it("has a slot", async () => {
     const page = await newE2EPage();
 
     await page.setContent("<calcite-shell-panel></calcite-shell-panel>");
     const element = await page.find("calcite-shell-panel");
-    expect(element).toHaveClass("hydrated");
-  });
-
-  it("defaults", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent("<calcite-shell-panel></calcite-shell-panel>");
-    const element = await page.find("calcite-shell-panel");
-
-    const layout = await element.getProperty("layout");
-
-    expect(layout).toBe("leading");
-
-    const collapsed = await element.getProperty("collapsed");
-
-    expect(collapsed).toBe(false);
-
     expect(element.shadowRoot.firstElementChild.tagName).toBe("SLOT");
   });
 

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -1,13 +1,10 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-shell", () => {
-  it("renders", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-shell"));
 
-    await page.setContent("<calcite-shell></calcite-shell>");
-    const element = await page.find("calcite-shell");
-    expect(element).toHaveClass("hydrated");
-  });
+  it("honors hidden attribute", async () => hidden("calcite-shell"));
 
   it("defaults", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-tip-group/calcite-tip-group.e2e.ts
+++ b/src/components/calcite-tip-group/calcite-tip-group.e2e.ts
@@ -1,11 +1,7 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-tip-group", () => {
-  it("should render without errors", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-tip-group"));
 
-    await page.setContent(`<calcite-tip-group></calcite-tip-group>`);
-    const tipGroup = await page.find("calcite-tip-group");
-    expect(tipGroup).not.toBeNull();
-  });
+  it("honors hidden attribute", async () => hidden("calcite-tip-group"));
 });

--- a/src/components/calcite-tip/calcite-tip.e2e.ts
+++ b/src/components/calcite-tip/calcite-tip.e2e.ts
@@ -1,18 +1,10 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-tip", () => {
-  it("should render and be visible", async () => {
-    const page = await newE2EPage();
+  it("renders", async () => renders("calcite-tip"));
 
-    await page.setContent(`<calcite-tip><p>basic render</p></calcite-tip>`).catch((error) => {
-      console.error(error);
-    });
-
-    const tip = await page.find("calcite-tip");
-    expect(tip).not.toBeNull();
-    const isVisible = await tip.isVisible();
-    expect(isVisible).toBe(true);
-  });
+  it("honors hidden attribute", async () => hidden("calcite-tip"));
 
   it("should remove the closeButton if nonDismissible prop is true", async () => {
     const page = await newE2EPage();


### PR DESCRIPTION
**Related Issue:** #207 

## Summary

Updates other tests to use any applicable test helpers (mostly `renders` and `hidden`).  

Note that I left `calcite-tip-manager` alone since it was showing some console errors (JSHandle@object) when I switched them over to the utils. 

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
