### PR TITLE
Change prefer-conditional-expression rule severity to warning.

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -12,6 +12,9 @@
     },
     "no-consecutive-blank-lines": {
       "options": [1]
+    },
+    "prefer-conditional-expression": {
+      "severity": "warn"
     }
   },
   "rulesDirectory": ["node_modules/tslint-lines-between-class-members"]


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Per today's meeting, changing severity of `prefer-conditional-expression` rule to warning.
