### PR TITLE
Issue 192: Use JSDoc for slots.

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -8,6 +8,9 @@ import { getElementDir } from "../utils/dom";
 
 import { CSS } from "./resources";
 
+/**
+ * @slot bottom-actions - A slot for adding `calcite-actions` that will appear at the bottom of the action bar, above the collapse/expand button.
+ */
 @Component({
   tag: "calcite-action-bar",
   styleUrl: "calcite-action-bar.scss",

--- a/src/components/calcite-action-bar/readme.md
+++ b/src/components/calcite-action-bar/readme.md
@@ -6,12 +6,6 @@ The `calcite-action-bar` component is made up of multiple `calcite-actions` in t
 
 See the [calcite-action-bar demo](https://esri.github.io/calcite-app-components/demos/calcite-action-bar.html).
 
-## Slots
-
-| Name             | Description                                                                                                            | Type                |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `bottom-actions` | A slot for adding `calcite-actions` that will apear at the bottom of the action bar, above the collapse/expand button. | `HTMLCalciteAction` |
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -6,6 +6,9 @@ import { CalciteTheme } from "../interfaces";
 
 const CONTROL_SLOT_NAME = "control";
 
+/**
+ * @slot control - A slot for adding a single HTML input element in a header.
+ */
 @Component({
   tag: "calcite-block",
   styleUrl: "calcite-block.scss",

--- a/src/components/calcite-block/readme.md
+++ b/src/components/calcite-block/readme.md
@@ -4,12 +4,6 @@ The `calcite-block` component is intended for displaying content on it's own as 
 
 See the [calcite-block demo](https://esri.github.io/calcite-app-components/demos/calcite-block.html).
 
-## Slots
-
-| Name      | Description                                                | Type               |
-| --------- | ---------------------------------------------------------- | ------------------ |
-| `control` | A slot for adding a single HTML input element in a header. | `HTMLInputElement` |
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -13,6 +13,10 @@ import { CalciteTheme } from "../interfaces";
 
 import { CSS_UTILITY } from "../utils/resources";
 
+/**
+ * @slot menu-actions - A slot for adding `calcite-actions` to a menu under the `...` in the header. These actions are displayed when the menu is open.
+ * @slot footer-actions - A slot for adding `calcite-actions` to the footer.
+ */
 @Component({
   tag: "calcite-flow-item",
   styleUrl: "calcite-flow-item.scss",

--- a/src/components/calcite-flow-item/readme.md
+++ b/src/components/calcite-flow-item/readme.md
@@ -4,13 +4,6 @@ A `calcite-flow-item` is a child element of `calcite-flow` and lives in a panel 
 
 See the [calcite-flow-item demo](https://esri.github.io/calcite-app-components/demos/calcite-flow-item.html).
 
-## Slots
-
-| Name             | Description                                                                                                                     | Type                |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `menu-actions`   | A slot for adding `calcite-actions` to a menu under the `...` in the header. These actions are displayed when the menu is open. | `HTMLCalciteAction` |
-| `footer-actions` | A slot for adding `calcite-actions` to the footer.                                                                              | `HTMLCalciteAction` |
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -4,6 +4,11 @@ import { CSS } from "./resources";
 
 import { CalciteLayout } from "../interfaces";
 
+/**
+ * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
+ * @slot shell-floating-panel - A slot for adding `calcite-shell-floating-panel` to the panel. The floating panel will be positioned relative to the shell panel when displayed.
+ * @slot action-pad - A slot for adding a `calcite-action-pad` to the panel. The action pad will be positioned relative to the shell panel when displayed.
+ */
 @Component({
   tag: "calcite-shell-panel",
   styleUrl: "calcite-shell-panel.scss",

--- a/src/components/calcite-shell-panel/readme.md
+++ b/src/components/calcite-shell-panel/readme.md
@@ -4,14 +4,6 @@ The `calcite-shell-panel` is a child component of `calcite-shell` used to house 
 
 See the [calcite-shell-panel demo](https://esri.github.io/calcite-app-components/demos/calcite-shell-panel.html).
 
-## Slots
-
-| Name                   | Description                                                                                                                                      | Type                            |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `action-bar`           | A slot for adding a `calcite-action-bar` to the panel.                                                                                           | `HTMLCalciteActionBar`          |
-| `shell-floating-panel` | A slot for adding `calcite-shell-floating-panel` to the panel. The floating panel will be positioned relative to the shell panel when displayed. | `HTMLCalciteShellFloatingPanel` |
-| `action-pad`           | A slot for adding a `calcite-action-pad` to the panel. The action pad will be positioned relative to the shell panel when displayed.             | `HTMLCalciteActionPad`          |
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -4,6 +4,13 @@ import { CSS } from "./resources";
 
 import { CalciteTheme } from "../interfaces";
 
+/**
+ * @slot shell-header - A slot for adding header content. This content will be positioned at the top of the shell.
+ * @slot shell-footer - A slot for adding footer content. This content will be positioned at the bottom of the shell.
+ * @slot primary-panel - A slot for adding the leading `calcite-shell-panel`.
+ * @slot contextual-panel - A slot for adding the trailing `calcite-shell-panel`.
+ * @slot tip-manager - A slot for adding a `calcite-tip-manager`. This component will be absolutely positioned.
+ */
 @Component({
   tag: "calcite-shell",
   styleUrl: "calcite-shell.scss",

--- a/src/components/calcite-shell/readme.md
+++ b/src/components/calcite-shell/readme.md
@@ -4,16 +4,6 @@ The `calcite-shell` component is used for application layout management. It is a
 
 See the [calcite-shell demo](https://esri.github.io/calcite-app-components/demos/calcite-shell.html).
 
-## Slots
-
-| Name               | Description                                                                                   | Type                    |
-| ------------------ | --------------------------------------------------------------------------------------------- | ----------------------- |
-| `shell-header`     | A slot for adding header content. This content will be positioned at the top of the shell.    | `HTMLElement`           |
-| `shell-footer`     | A slot for adding footer content. This content will be positioned at the bottom of the shell. | `HTMLElement`           |
-| `primary-panel`    | A slot for adding the leading `calcite-shell-panel`.                                          | `HTMLCalciteShellPanel` |
-| `contextual-panel` | A slot for adding the trailing `calcite-shell-panel`.                                         | `HTMLCalciteShellPanel` |
-| `tip-manager`      | A slot for adding a `calcite-tip-manager`. This component will be absolutely positioned.      | `HTMLCalciteTipManager` |
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -5,6 +5,10 @@ import CalciteIcon from "../utils/CalciteIcon";
 import { CalciteTheme } from "../interfaces";
 import { CSS, TEXT } from "./resources";
 
+/**
+ * @slot info - A slot for adding an HTML element to the body of the tip.
+ * @slot link - A slot for adding an HTML anchor element to the body of the tip.
+ */
 @Component({
   tag: "calcite-tip",
   styleUrl: "./calcite-tip.scss",

--- a/src/components/calcite-tip/readme.md
+++ b/src/components/calcite-tip/readme.md
@@ -4,13 +4,6 @@ The `calcite-tip` component can comprise of an image, text and hyperlink to give
 
 See the [calcite-tip demo](https://esri.github.io/calcite-app-components/demos/calcite-tip.html).
 
-## Slots
-
-| Name   | Description                                                      | Type                |
-| ------ | ---------------------------------------------------------------- | ------------------- |
-| `info` | A slot for adding an HTML element to the body of the tip.        | `HTMLElement`       |
-| `link` | A slot for adding an HTML anchor element to the body of the tip. | `HTMLAnchorElement` |
-
 <!-- Auto Generated Below -->
 
 ## Properties


### PR DESCRIPTION
**Related Issue:** #192

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Uses JSDoc to have the Stencil build auto-generate slot doc.

**Note**: Doc will be updated on `master` after merging.

cc @kat10140 