### PR TITLE
fix: pre-populate state with preselected items

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -50,6 +50,24 @@ describe("calcite-pick-list", () => {
         expect(toggleSpy).toHaveReceivedEventTimes(3);
       });
     });
+    describe("preselected items", () => {
+      it("should be included in the list of selected items", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<calcite-pick-list multiple>
+          <calcite-pick-list-item value="one" selected></calcite-pick-list-item>
+          <calcite-pick-list-item value="two"></calcite-pick-list-item>
+        </calcite-pick-list>`);
+
+        const numSelected = await page.evaluate(() => {
+          const pickList = document.querySelector("calcite-pick-list");
+          return pickList.getSelectedItems().then((result) => {
+            return result.size;
+          });
+        });
+
+        expect(numSelected).toBe(1);
+      });
+    });
   });
 
   describe("icon logic", () => {

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -144,6 +144,9 @@ export class CalcitePickList {
       } else {
         item.removeAttribute("icon");
       }
+      if (item.hasAttribute("selected")) {
+        this.selectedValues.set(item.getAttribute("value"), item);
+      }
     });
     if (this.dragEnabled && this.mode === "configuration") {
       this.setUpDragAndDrop();


### PR DESCRIPTION
**Related Issue:** #274 

## Summary

pre-selected items in a pickList are now added to the selectedValues map on initial load. This means the list of selectedValues will now be correct when setting pre-selected items on the pickList.