### PR TITLE
remove undocumented `dismissed` attribute in favor of hidden. A devel…

### DIFF
--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -15,11 +15,6 @@ $tip-image-max-width: 100% !default;
   border-radius: var(--calcite-app-border-radius);
 }
 
-:host([hidden]),
-:host([dismissed]) {
-  display: none;
-}
-
 :host([selected]) {
   box-shadow: none;
   margin: 0;

--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -26,6 +26,10 @@ $tip-image-max-width: 100% !default;
   padding-right: 0;
 }
 
+.container[hidden] {
+  display: none;
+}
+
 .content {
   display: flex;
   padding-top: var(--calcite-app-cap-spacing-half);

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -102,32 +102,34 @@ export class CalciteTip {
 
   render() {
     return (
-      <Host hidden={this.dismissed}>
-        <header class={CSS.header}>
-          <h3 class={CSS.heading}>{this.heading}</h3>
-          {!this.nonDismissible ? (
-            <calcite-action text={this.textClose} onClick={this.hideTip} class={CSS.close}>
-              <CalciteIcon size="16" path={x16} />
-            </calcite-action>
-          ) : null}
-        </header>
-        <div class={CSS.content}>
-          {this.thumbnail ? (
-            <div class={CSS.imageFrame}>
-              <img src={this.thumbnail} alt={this.textThumbnail} />
-            </div>
-          ) : null}
-
-          <div class={CSS.info}>
-            {this.el.querySelector("[slot=info]") ? <slot name="info" /> : null}
-
-            {this.el.querySelector("[slot=link]") ? (
-              <p class={CSS.link}>
-                <slot name="link" />
-              </p>
+      <Host>
+        <article class={CSS.container} hidden={this.dismissed}>
+          <header class={CSS.header}>
+            <h3 class={CSS.heading}>{this.heading}</h3>
+            {!this.nonDismissible ? (
+              <calcite-action text={this.textClose} onClick={this.hideTip} class={CSS.close}>
+                <CalciteIcon size="16" path={x16} />
+              </calcite-action>
             ) : null}
+          </header>
+          <div class={CSS.content}>
+            {this.thumbnail ? (
+              <div class={CSS.imageFrame}>
+                <img src={this.thumbnail} alt={this.textThumbnail} />
+              </div>
+            ) : null}
+
+            <div class={CSS.info}>
+              {this.el.querySelector("[slot=info]") ? <slot name="info" /> : null}
+
+              {this.el.querySelector("[slot=link]") ? (
+                <p class={CSS.link}>
+                  <slot name="link" />
+                </p>
+              ) : null}
+            </div>
           </div>
-        </div>
+        </article>
       </Host>
     );
   }

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -102,7 +102,7 @@ export class CalciteTip {
 
   render() {
     return (
-      <Host dismissed={this.dismissed}>
+      <Host hidden={this.dismissed}>
         <header class={CSS.header}>
           <h3 class={CSS.heading}>{this.heading}</h3>
           {!this.nonDismissible ? (

--- a/src/components/calcite-tip/resources.ts
+++ b/src/components/calcite-tip/resources.ts
@@ -1,4 +1,5 @@
 export const CSS = {
+  container: "container",
   header: "header",
   heading: "heading",
   close: "close",


### PR DESCRIPTION
Removes undocumented `dismissed` attribute in favor of hidden.

**Related Issue:** None

## Summary

`dismissed` isn't a custom attribute that is defined on the component so we probably shouldn't use it as one.

A developer can remove hidden if necessary which is an added benefit. Currently, they can't unhide once hidden.

Eliminates some CSS as well.
