### PR TITLE
fix: pick list needs to be visible to be clicked by puppeteer

### DIFF
--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
@@ -11,10 +11,10 @@ describe("calcite-pick-list-item", () => {
     expect(isVisible).toBe(true);
   });
 
-  it.skip("should toggle selected attribute when clicked", async () => {
+  it("should toggle selected attribute when clicked", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-pick-list-item></calcite-pick-list-item>`);
+    await page.setContent(`<calcite-pick-list-item text-heading="test"></calcite-pick-list-item>`);
     const item = await page.find("calcite-pick-list-item");
     expect(await item.getProperty("selected")).toBe(false);
     await item.click();


### PR DESCRIPTION
**Related Issue:** #

## Summary

Fixed the test. Puppeteer click() method will fail if the element you're trying to click is not visible. This will happen if it has zero width and zero height so for the pick-list-item I had to give it a heading so it had some content.