### PR TITLE
deprecating props on pickList

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -27,27 +27,28 @@ export class CalcitePickList {
   // --------------------------------------------------------------------------
 
   /**
-   * When true, the items will be sortable via drag and drop.
-   * Only applies when mode is configuration
-   */
-  @Prop({ reflect: true }) dragEnabled = false;
-
-  /**
-   * Mode controls the presentation of the items in their selected and deselected states.
-   * Selection mode shows either radio buttons or checkboxes depending on the value of multiple
-   * Configuration mode relies on a color highlight on the edge of the item for selected
-   * Mode must be set to configuration for drag and drop behavior to work.
-   */
-  @Prop({ reflect: true }) mode: "selection" | "configuration" = "selection";
-
-  /**
-   * Multpile Works similar to standard radio buttons and checkboxes.
+   * Multiple Works similar to standard radio buttons and checkboxes.
    * It also affects the presented icon when in Selection mode.
    * When true, a user can select multiple items at a time.
    * When false, only a single item can be selected at a time,
    * When false, selecting a new item will deselect any other selected items.
    */
   @Prop({ reflect: true }) multiple = false;
+
+  /**
+   * DEPRECATED: No longer rendered. Prop will be removed in a future release.
+   */
+  @Prop({ reflect: true }) textHeading: string;
+
+  /**
+   * DEPRECATED: `<calcite-value-list>` will support drag and drop. Prop will be removed in a future release.
+   */
+  @Prop({ reflect: true }) dragEnabled = false;
+
+  /**
+   * DEPRECATED: configuration mode is now `<calcite-value-list>`. Prop will be removed in a future release.
+   */
+  @Prop({ reflect: true }) mode: "selection" | "configuration" = "selection";
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -27,6 +27,20 @@ export class CalcitePickList {
   // --------------------------------------------------------------------------
 
   /**
+   * When true, the items will be sortable via drag and drop.
+   * Only applies when mode is configuration
+   */
+  @Prop({ reflect: true }) dragEnabled = false;
+
+  /**
+   * Mode controls the presentation of the items in their selected and deselected states.
+   * Selection mode shows either radio buttons or checkboxes depending on the value of multiple
+   * Configuration mode relies on a color highlight on the edge of the item for selected
+   * Mode must be set to configuration for drag and drop behavior to work.
+   */
+  @Prop({ reflect: true }) mode: "selection" | "configuration" = "selection";
+
+  /**
    * Multiple Works similar to standard radio buttons and checkboxes.
    * It also affects the presented icon when in Selection mode.
    * When true, a user can select multiple items at a time.
@@ -39,16 +53,6 @@ export class CalcitePickList {
    * DEPRECATED: No longer rendered. Prop will be removed in a future release.
    */
   @Prop({ reflect: true }) textHeading: string;
-
-  /**
-   * DEPRECATED: `<calcite-value-list>` will support drag and drop. Prop will be removed in a future release.
-   */
-  @Prop({ reflect: true }) dragEnabled = false;
-
-  /**
-   * DEPRECATED: configuration mode is now `<calcite-value-list>`. Prop will be removed in a future release.
-   */
-  @Prop({ reflect: true }) mode: "selection" | "configuration" = "selection";
 
   // --------------------------------------------------------------------------
   //


### PR DESCRIPTION
## Summary
In order to avoid generating breaking changes with this release, we're deprecating but keeping props no longer used on the PickList.

* Adding back `textHeading` prop but marking it deprecated in JSDoc.
* Also deprecating `mode` and `dragEnabled` as these will be removed once valueList is merged. Could wait to deprecate these until that's ready.