### PR TITLE
add pre-select logic on componentDidLoad

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -91,6 +91,11 @@ export class CalcitePickList {
   }
 
   componentDidLoad() {
+    this.items.forEach((item) => {
+      if (item.hasAttribute("selected")) {
+        this.selectedValues.set(item.getAttribute("value"), item);
+      }
+    });
     this.observer.observe(this.el, { childList: true, subtree: true });
   }
 


### PR DESCRIPTION
**Related Issue:** #274 

## Summary
* There's some strange behavior happening in Adelheide's environment. Perhaps it's Maquette but the connectedCallback() for pickList is firing before the pick-list-items render.
So in order to get the pre-selection working I've had to move that logic to componentDidLoad.
* I've left it in setUpItems so it runs when the mutation observer callback fires. This means it gets called twice on first load but the Map prevents duplicate entries, so its ok. Could possibly clean this up more.