### PR TITLE
Change @esri/calcite-colors version to NPM package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,8 +226,9 @@
       }
     },
     "@esri/calcite-base": {
-      "version": "github:Esri/calcite-base#3d18d243f5d2d9fb80a450b7a4950381a6048f1d",
-      "from": "github:Esri/calcite-base#3d18d24"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-base/-/calcite-base-1.1.0.tgz",
+      "integrity": "sha512-OgDLlEdcN5gI+AV4l+tPWxYtHFQViZJMpaHS5Hw4W7cQGlUjslq/RmXjKJ5Mf5voaY6VSe5apF4dXloRWjoJtw=="
     },
     "@esri/calcite-colors": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/Esri/calcite-app-components.git"
   },
   "dependencies": {
-    "@esri/calcite-base": "github:Esri/calcite-base#3d18d24",
+    "@esri/calcite-base": "1.1.0",
     "@esri/calcite-colors": "1.2.1",
     "@esri/calcite-ui-icons": "2.5.0",
     "sortablejs": "1.10.0-rc3"

--- a/src/assets/styles/_color.scss
+++ b/src/assets/styles/_color.scss
@@ -1,3 +1,14 @@
+$white: $blk-000;
+$gray: $blk-130;
+$light-gray: $blk-030;
+$lighter-gray: $blk-020;
+$lightest-gray: $blk-010;
+$darker-gray: $blk-180;
+$darkest-gray: $blk-200;
+$off-black: $blk-220;
+$blue: $h-bb-060;
+$dark-blue: $h-bb-070;
+$lightest-blue: $h-bb-010;
 $vibrant-blue: $v-bb-120;
 
 @mixin calciteLightThemeVars {

--- a/src/assets/styles/includes.scss
+++ b/src/assets/styles/includes.scss
@@ -1,4 +1,4 @@
-@import "./node_modules/@esri/calcite-colors/colors.scss";
+@import "./node_modules/@esri/calcite-colors/colors";
 @import "./node_modules/@esri/calcite-base/dist/variables";
 @import "./_mixins";
 @import "./_type";


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Moves the `@esri/calcite-colors` dep to NPM.

**Note**: I had to move over some CSS vars because of [this @esri/calcite-base commit](https://github.com/Esri/calcite-base/commit/bc5d4fc50a4ec93fba852e6045995d684792289f#diff-2a6d07eef8b10b84129b42424ed99327). 
