### PR TITLE
 replace npm install with npm ci in preversion script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:headed": "stencil test --spec --e2e --devtools",
     "test:watch": "stencil test --spec --e2e --watch",
     "test:watchAll": "stencil test --spec --e2e --watchAll",
-    "preversion": "npm install && npm test",
+    "preversion": "npm ci && npm test",
     "version": "npm run build && npm run docs && git add .",
     "postversion": "git push && git push --tags",
     "prepublishOnly": "node ./support/prepublish.js",


### PR DESCRIPTION
## Summary

After reading up on this, it seems like it would be better to use `npm ci` instead of `npm install` for deployments. This will also be relevant when getting `travis` working.
https://docs.npmjs.com/cli/ci.html

