### PR TITLE
#307 key navigation only works on specified target

### DIFF
--- a/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
@@ -73,6 +73,9 @@ describe("calcite-tip-manager", () => {
       let selectedTip = await tipManager.find(`calcite-tip[selected]`);
       expect(selectedTip.id).toEqual("one"); // default selected tip is index 0
 
+      let paginationText = await page.find(`calcite-tip-manager >>> .${CSS.pagePosition}`);
+      expect(paginationText.textContent).toEqual("Tip 1/2");
+
       const nextButton = await page.find(`calcite-tip-manager >>> .${CSS.pageNext}`);
       await nextButton.click();
       await page.waitForChanges();
@@ -80,12 +83,18 @@ describe("calcite-tip-manager", () => {
       selectedTip = await tipManager.find(`calcite-tip[selected]`);
       expect(selectedTip.id).toEqual("two");
 
+      paginationText = await page.find(`calcite-tip-manager >>> .${CSS.pagePosition}`);
+      expect(paginationText.textContent).toEqual("Tip 2/2");
+
       const previousButton = await page.find(`calcite-tip-manager >>> .${CSS.pagePrevious}`);
       await previousButton.click();
       await page.waitForChanges();
 
       selectedTip = await tipManager.find(`calcite-tip[selected]`);
       expect(selectedTip.id).toEqual("one");
+
+      paginationText = await page.find(`calcite-tip-manager >>> .${CSS.pagePosition}`);
+      expect(paginationText.textContent).toEqual("Tip 1/2");
     });
 
     // TODO: split the group-title test into one for first render, and another for pagination

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -187,7 +187,7 @@ export class CalciteTipManager {
     this.nextTip();
   };
 
-  tipManagerKeyDownHandler = (event: KeyboardEvent): void => {
+  tipManagerKeyUpHandler = (event: KeyboardEvent): void => {
     if (event.target !== this.container) {
       return;
     }
@@ -210,6 +210,10 @@ export class CalciteTipManager {
         this.selectedIndex = this.total - 1;
         break;
     }
+  };
+
+  storeContainerRef = (el: HTMLDivElement) => {
+    this.container = el;
   };
 
   // --------------------------------------------------------------------------
@@ -249,11 +253,7 @@ export class CalciteTipManager {
     }
     return (
       <Host>
-        <div
-          tabindex="0"
-          onKeyUp={this.tipManagerKeyDownHandler}
-          ref={(el) => (this.container = el as HTMLDivElement)}
-        >
+        <div tabindex="0" onKeyUp={this.tipManagerKeyUpHandler} ref={this.storeContainerRef}>
           <header class={CSS.header}>
             <h2 key={selectedIndex} class={CSS.heading}>
               {groupTitle}

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -84,6 +84,8 @@ export class CalciteTipManager {
 
   observer = new MutationObserver(() => this.setUpTips());
 
+  container: HTMLDivElement;
+
   // --------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -186,15 +188,17 @@ export class CalciteTipManager {
   };
 
   tipManagerKeyDownHandler = (event: KeyboardEvent): void => {
+    if (event.target !== this.container) {
+      return;
+    }
+
     switch (event.key) {
-      case "ArrowUp":
-        event.preventDefault();
       case "ArrowRight":
+        event.preventDefault();
         this.nextTip();
         break;
-      case "ArrowDown":
-        event.preventDefault();
       case "ArrowLeft":
+        event.preventDefault();
         this.previousTip();
         break;
       case "Home":
@@ -242,8 +246,12 @@ export class CalciteTipManager {
       return <Host />;
     }
     return (
-      <Host onKeydown={this.tipManagerKeyDownHandler}>
-        <div tabindex="0">
+      <Host>
+        <div
+          tabindex="0"
+          onKeyUp={this.tipManagerKeyDownHandler}
+          ref={(el) => (this.container = el as HTMLDivElement)}
+        >
           <header class={CSS.header}>
             <h2 key={selectedIndex} class={CSS.heading}>
               {groupTitle}

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -220,7 +220,9 @@ export class CalciteTipManager {
 
   renderPagination() {
     const dir = getElementDir(this.el);
-    return this.tips.length > 1 ? (
+    const { selectedIndex, tips, total } = this;
+
+    return tips.length > 1 ? (
       <footer class={CSS.pagination}>
         <calcite-action
           text={this.textPrevious}
@@ -229,8 +231,8 @@ export class CalciteTipManager {
         >
           <CalciteIcon size="16" path={dir === "ltr" ? chevronLeft16 : chevronRight16} />
         </calcite-action>
-        <span class={CSS.pagePosition}>
-          {`${this.textPaginationLabel} ${this.selectedIndex + 1}/${this.total}`}
+        <span key={selectedIndex} class={CSS.pagePosition}>
+          {`${this.textPaginationLabel} ${selectedIndex + 1}/${total}`}
         </span>
         <calcite-action text={this.textNext} onClick={this.nextClicked} class={CSS.pageNext}>
           <CalciteIcon size="16" path={dir === "ltr" ? chevronRight16 : chevronLeft16} />


### PR DESCRIPTION
Bug: User should not be able to use arrow keys on tip manager navigation buttons 
Bug: Keyboard Users should be able to scroll content inside of a tip manager

**Related Issue:** 

#307 key navigation only works on specified target
#306 allow scrolling via arrows inside content
Fixes pagination text not updating. Needs key to know to update.

## Summary

Fixes accessibility issues.
