### PR TITLE
Issue #308: Ensure Block header focus outline is visible.

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -4,7 +4,6 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
   display: flex;
   flex-direction: column;
   border-radius: var(--calcite-app-border-radius);
-  overflow: hidden;
   box-shadow: 0 1px 0 var(--calcite-app-border);
   margin: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
   background-color: var(--calcite-app-background);
@@ -58,6 +57,6 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
 
 .content {
   background-color: var(--calcite-app-background);
-  padding: 0 var(--calcite-app-side-spacing-half) var(--calcite-app-cap-spacing-half);
+  padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
   animation: calcite-app-fade-in var(--calcite-app-animation-time) var(--calcite-app-easing-function);
 }


### PR DESCRIPTION
**Related Issue:** #308

## Summary

- [x] changes have been tested with demo page in Edge

Tweaks CSS to keep focus outline visible.

@asangma I added some space to the top of a section to prevent the following:

<img width="328" alt="Screen Shot 2019-10-01 at 9 43 46 AM" src="https://user-images.githubusercontent.com/197440/65984937-aa1df380-e435-11e9-9892-c2c6364d76ac.png">

**after spacing**

<img width="315" alt="Screen Shot 2019-10-01 at 9 44 00 AM" src="https://user-images.githubusercontent.com/197440/65982877-24984480-e431-11e9-8485-ae5f542936de.png">

