### PR TITLE
Issue #152: Add master to branch-building safelist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - "node"
+branches:
+  only:
+    - master


### PR DESCRIPTION
**Related Issue:** #152

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This will allow `master` to be built so the build status badge is updated properly.

cc @kat10140 