### PR TITLE
Nixed animations to fix flicker.

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -1,9 +1,9 @@
 :host {
   display: block;
+  margin-bottom: var(--calcite-app-cap-spacing-quarter);
 }
 
 .content {
   background-color: var(--calcite-app-background);
   padding: 0 var(--calcite-app-side-spacing-half) var(--calcite-app-cap-spacing-half);
-  animation: calcite-app-fade-in var(--calcite-app-animation-time) var(--calcite-app-easing-function);
 }

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
 
-import { caretDown16F, caretLeft16F, caretRight16F } from "@esri/calcite-ui-icons";
+import { caretDown16, caretLeft16, caretRight16 } from "@esri/calcite-ui-icons";
 import { getElementDir } from "../utils/dom";
 import { CSS, TEXT } from "./resources";
 import CalciteIcon from "../utils/CalciteIcon";
@@ -82,7 +82,7 @@ export class CalciteBlockSection {
   render() {
     const { el, open, textCollapse, textExpand } = this;
     const dir = getElementDir(el);
-    const arrowIcon = open ? caretDown16F : dir === "rtl" ? caretLeft16F : caretRight16F;
+    const arrowIcon = open ? caretDown16 : dir === "rtl" ? caretLeft16 : caretRight16;
     const toggleLabel = open ? textCollapse : textExpand;
 
     const headerNode = (

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -58,5 +58,4 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
 .content {
   background-color: var(--calcite-app-background);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
-  animation: calcite-app-fade-in var(--calcite-app-animation-time) var(--calcite-app-easing-function);
 }


### PR DESCRIPTION
Also updated section focus overlap.
Includes icon update for sections.

**Related Issue:** #308

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

cc @annelfitz 
