### PR TITLE
Light refactoring of background and foreground CSS var usage

### DIFF
--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -1,4 +1,5 @@
 :host {
+  background-color: var(--calcite-app-background);
   font-family: var(--calcite-app-font-family);
   font-size: var(--calcite-app-base-font-size);
   line-height: var(--calcite-app-line-height);
@@ -13,13 +14,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: var(--calcite-app-background);
 }
 
 .heading {
   padding: 0;
   margin: 0;
-  color: var(--calcite-app-foreground);
 }
 
 .header .heading {

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -1,5 +1,6 @@
 :host {
   background-color: var(--calcite-app-background);
+  color: var(--calcite-app-foreground);
   font-family: var(--calcite-app-font-family);
   font-size: var(--calcite-app-base-font-size);
   line-height: var(--calcite-app-line-height);

--- a/src/components/calcite-action-bar/calcite-action-bar.scss
+++ b/src/components/calcite-action-bar/calcite-action-bar.scss
@@ -1,5 +1,4 @@
 :host {
-  background-color: var(--calcite-app-background);
   height: 100%;
   padding: 0 var(--calcite-app-side-spacing-quarter);
   display: flex;

--- a/src/components/calcite-action-pad/calcite-action-pad.scss
+++ b/src/components/calcite-action-pad/calcite-action-pad.scss
@@ -1,11 +1,11 @@
 :host {
+  background-color: var(--calcite-app-background);
+  color: var(--calcite-app-foreground);
   display: flex;
 }
 
 .container {
-  background-color: var(--calcite-app-background);
   display: flex;
-  color: var(--calcite-app-foreground);
   flex-direction: column;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
   padding: var(--calcite-app-cap-spacing-eighth) var(--calcite-app-side-spacing-quarter);

--- a/src/components/calcite-action-pad/calcite-action-pad.scss
+++ b/src/components/calcite-action-pad/calcite-action-pad.scss
@@ -1,6 +1,4 @@
 :host {
-  background-color: var(--calcite-app-background);
-  color: var(--calcite-app-foreground);
   display: flex;
 }
 

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -1,10 +1,10 @@
 :host {
+  background-color: var(--calcite-app-background);
   display: block;
   margin-bottom: var(--calcite-app-cap-spacing-quarter);
 }
 
 .content {
-  background-color: var(--calcite-app-background);
   border-top: 1px solid var(--calcite-app-border);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
 }

--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -1,5 +1,4 @@
 :host {
-  background-color: var(--calcite-app-background);
   display: block;
   margin-bottom: var(--calcite-app-cap-spacing-quarter);
 }

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -15,8 +15,6 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
 }
 
 .header-container {
-  background-color: var(--calcite-app-background);
-
   & > .header {
     padding: $header-content-padding;
   }
@@ -33,7 +31,6 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
 .summary {
   font-size: var(--font-size--1);
   padding: 0 var(--calcite-app-side-spacing-half);
-  color: var(--calcite-app-foreground);
 }
 
 .toggle {
@@ -52,7 +49,7 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
 
 .toggle-icon {
   margin: 0 4px;
-  fill: var(--calcite-app-foreground);
+  fill: currentColor;
 }
 
 .content {

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -6,8 +6,6 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
   border-radius: var(--calcite-app-border-radius);
   box-shadow: 0 1px 0 var(--calcite-app-border);
   margin: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
-  background-color: var(--calcite-app-background);
-  color: var(--calcite-app-foreground);
 }
 
 :host([open]) {
@@ -53,6 +51,5 @@ $header-content-padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-s
 }
 
 .content {
-  background-color: var(--calcite-app-background);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
 }

--- a/src/components/calcite-filter/calcite-filter.scss
+++ b/src/components/calcite-filter/calcite-filter.scss
@@ -1,5 +1,4 @@
 :host {
-  background-color: var(--calcite-app-background);
   display: flex;
   padding: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-half);
   width: 100%;

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -20,13 +20,11 @@
 
 .header {
   align-items: center;
-  color: var(--calcite-app-foreground);
   display: flex;
   padding: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-half);
   justify-content: flex-start;
   position: relative;
   z-index: 2;
-  background-color: var(--calcite-app-background);
   border-bottom: 1px solid var(--calcite-app-border);
   justify-content: flex-start;
 }
@@ -45,7 +43,6 @@
 
 .footer {
   align-items: center;
-  background-color: var(--calcite-app-background);
   border-top: 1px solid var(--calcite-app-border);
   display: flex;
   justify-content: space-around;

--- a/src/components/calcite-shell/calcite-shell.scss
+++ b/src/components/calcite-shell/calcite-shell.scss
@@ -44,7 +44,5 @@ $shell-min-width: 1024px !default; // ipad
 }
 
 .footer {
-  background-color: var(--calcite-app-background);
-  color: var(--calcite-app-foreground);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing);
 }

--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -25,12 +25,10 @@ $tip-max-width: 540px;
 
 /* Component Styles */
 :host {
-  color: var(--calcite-app-foreground);
   overflow: hidden;
   position: relative;
   display: block;
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half) 0;
-  background-color: var(--calcite-app-background);
   min-height: 150px;
 }
 

--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -25,6 +25,7 @@ $tip-max-width: 540px;
 
 /* Component Styles */
 :host {
+  color: var(--calcite-app-foreground);
   overflow: hidden;
   position: relative;
   display: block;
@@ -47,7 +48,6 @@ $tip-max-width: 540px;
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  background-color: var(--calcite-app-background);
 }
 
 ::slotted(calcite-tip-group) {
@@ -79,5 +79,4 @@ $tip-max-width: 540px;
 .page-position {
   font-size: var(--calcite-app-font-size--1);
   margin: 0 var(--calcite-app-side-spacing-half);
-  color: var(--calcite-app-foreground);
 }

--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -4,8 +4,6 @@ $tip-image-frame-width: 25% !default;
 $tip-image-max-width: 100% !default;
 
 :host {
-  background-color: var(--calcite-app-background);
-  color: var(--calcite-app-foreground);
   position: relative;
   display: flex;
   flex-flow: column;
@@ -53,7 +51,7 @@ $tip-image-max-width: 100% !default;
 }
 
 .info ::slotted(a) {
-  color: var(--calcite-app-foreground);
+  color: var(--calcite-app-foreground-link);
 }
 
 .image-frame {

--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -4,14 +4,14 @@ $tip-image-frame-width: 25% !default;
 $tip-image-max-width: 100% !default;
 
 :host {
+  background-color: var(--calcite-app-background);
+  color: var(--calcite-app-foreground);
   position: relative;
   display: flex;
   flex-flow: column;
 }
 
 .container {
-  color: var(--calcite-app-foreground);
-  background-color: var(--calcite-app-background);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing) var(--calcite-app-cap-spacing);
   margin: var(--calcite-app-cap-spacing) var(--calcite-app-side-spacing);
   box-shadow: var(--calcite-app-shadow-2);


### PR DESCRIPTION
**Related Issue:** #175

## Summary
Generally moved foreground and background color rules to higher level CSS blocks, e.g. `:host`.

Will make updates to pick-list, value-list, and pick-list-item as needed after #342 is merged.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
