### PR TITLE
fix: rename action to menu-actions slot in PickList and ValueList

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -12,6 +12,9 @@ import {
 } from "@stencil/core";
 import { ICON_TYPES, TEXT } from "./resources";
 
+/**
+ * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
+ */
 @Component({
   tag: "calcite-pick-list",
   styleUrl: "./calcite-pick-list.scss",
@@ -244,7 +247,7 @@ export class CalcitePickList {
               onCalciteFilterChange={this.handleFilter}
             />
           ) : null}
-          <slot name="action" />
+          <slot name="menu-actions" />
         </header>
         <slot />
       </Host>

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -14,6 +14,9 @@ import {
 import guid from "../utils/guid";
 import { CSS, ICON_TYPES, TEXT } from "./resources";
 
+/**
+ * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
+ */
 @Component({
   tag: "calcite-value-list",
   styleUrl: "./calcite-value-list.scss",
@@ -269,7 +272,7 @@ export class CalciteValueList {
               onCalciteFilterChange={this.handleFilter}
             />
           ) : null}
-          <slot name="action" />
+          <slot name="menu-actions" />
         </header>
         <slot />
       </Host>


### PR DESCRIPTION
## Summary

Rename `action` slot to `menu-actions`. This is the slot we're providing MapMaker team to do list sorting, etc.

Going to consider the incorrect name a bug, and this a bug fix.