### PR TITLE
fix(lists): added bg-color rules. 

### DIFF
--- a/src/assets/styles/_color.scss
+++ b/src/assets/styles/_color.scss
@@ -25,6 +25,7 @@ $vibrant-blue: $v-bb-120;
   --calcite-app-foreground-link: #{$blue};
 
   --calcite-app-background-content: #{$lightest-gray};
+  --calcite-app-background-clear: transparent;
 
   --calcite-app-border: #{$lighter-gray};
   --calcite-app-border-subtle: #{$lightest-gray};

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.scss
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.scss
@@ -1,4 +1,5 @@
 :host {
+  background-color: var(--calcite-app-background-clear);
   display: block;
 }
 

--- a/src/components/calcite-pick-list/calcite-pick-list.scss
+++ b/src/components/calcite-pick-list/calcite-pick-list.scss
@@ -1,5 +1,6 @@
 :host {
   align-items: stretch;
+  background-color: var(--calcite-app-background-clear);
   display: flex;
   flex-flow: column;
   padding-bottom: var(--calcite-app-cap-spacing-half);

--- a/src/components/calcite-value-list-item/calcite-value-list-item.scss
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.scss
@@ -1,4 +1,5 @@
 :host {
+  background-color: var(--calcite-app-background-clear);
   display: block;
 }
 

--- a/src/components/calcite-value-list/calcite-value-list.scss
+++ b/src/components/calcite-value-list/calcite-value-list.scss
@@ -1,6 +1,6 @@
 :host {
   align-items: stretch;
-  background-color: transparent;
+  background-color: var(--calcite-app-background-clear);
   display: flex;
   flex-flow: column;
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);


### PR DESCRIPTION
**Related Issue:** #364

## Summary
Added bg-color rules for lists.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
