### PR TITLE
style(block-section): use small calcite-switch.

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -103,7 +103,7 @@ export class CalciteBlockSection {
       toggleDisplay === "switch" ? (
         <label aria-label={toggleLabel} class={classnames(CSS.toggle, CSS.toggleSwitch)}>
           {text}
-          <calcite-switch switched={open} onChange={this.toggleSection} />
+          <calcite-switch switched={open} onChange={this.toggleSection} scale="s" />
         </label>
       ) : (
         <calcite-action


### PR DESCRIPTION
**Related Issue:** #370

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

cc @AdelheidF 