### PR TITLE
Issue #292: Move block a11y attributes to shadow DOM.

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
+import { Component, Element, Event, EventEmitter, Prop, h } from "@stencil/core";
 
 import { caretDown16, caretLeft16, caretRight16 } from "@esri/calcite-ui-icons";
 import { getElementDir } from "../utils/dom";
@@ -119,12 +119,12 @@ export class CalciteBlockSection {
       );
 
     return (
-      <Host aria-expanded={open ? "true" : "false"}>
+      <section aria-expanded={open ? "true" : "false"}>
         {headerNode}
         <div class={CSS.content} hidden={!open}>
           <slot />
         </div>
-      </Host>
+      </section>
     );
   }
 }

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
+import { Component, Element, Event, EventEmitter, Prop, h } from "@stencil/core";
 import { chevronDown16, chevronUp16 } from "@esri/calcite-ui-icons";
 import { CSS, TEXT } from "./resources";
 import CalciteIcon from "../utils/CalciteIcon";
@@ -156,14 +156,12 @@ export class CalciteBlock {
     const hasContent = !!Array.from(el.children).some((child) => child.slot !== CONTROL_SLOT_NAME);
 
     return (
-      <Host aria-expanded={collapsible ? (open ? "true" : "false") : null}>
-        <article>
-          {headerNode}
-          <div class={CSS.content} hidden={!hasContent || !open}>
-            <slot />
-          </div>
-        </article>
-      </Host>
+      <article aria-expanded={collapsible ? (open ? "true" : "false") : null}>
+        {headerNode}
+        <div class={CSS.content} hidden={!hasContent || !open}>
+          <slot />
+        </div>
+      </article>
     );
   }
 }


### PR DESCRIPTION
**Related Issue:** #292 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Moved a11y attrs down to shadow DOM in favor of obfuscating implementation details.
