### PR TITLE
Flow item demo and panel styling

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -2,6 +2,7 @@
   display: flex;
   height: 100%;
   font-size: var(--calcite-app-base-font-size);
+  position: relative;
 }
 
 .container {
@@ -11,7 +12,6 @@
   margin: 0;
   display: flex;
   flex-flow: column;
-  position: relative;
 }
 
 .container[hidden] {

--- a/src/demos/calcite-flow-item.html
+++ b/src/demos/calcite-flow-item.html
@@ -9,7 +9,16 @@
     <!-- Loads the link and script tags-->
     <script src="head.js"></script>
   </head>
-
+  <style>
+    .demo-block {
+      width: 100%;
+      height: 240px;
+      margin-bottom: 8px;
+      background-color: #fff;
+      border-radius: 3px;
+      box-shadow: 0 1px 0 #e0e0e0;
+    }
+  </style>
   <body>
     <nav>
       <calcite-demo-nav page-id="calcite-flow-item"></calcite-demo-nav>
@@ -30,8 +39,25 @@
             width: 350px;
             height: 800px;
           }
+          .demo-btn {
+            background-color: transparent;
+            border: 1px solid #007ac2;
+            color: #007ac2;
+            font-size: 1rem;
+            font-family: inherit;
+            padding: 0.7rem;
+            border-radius: 3px;
+            margin: 1rem 0.2rem;
+            min-width: 5rem;
+          }
+          .toggles {
+            margin: 1rem 0;
+          }
         </style>
-
+        <div class="toggles">
+          <calcite-button onclick="toggleProperty('loading')">Toggle loading</calcite-button>
+          <calcite-button onclick="toggleProperty('disabled')">Toggle disabled</calcite-button>
+        </div>
         <div class="flow-container">
           <calcite-flow-item heading="First Panel">
             <div slot="menu-actions">
@@ -47,5 +73,14 @@
         </div>
       </section>
     </main>
+    <script>
+      function toggleProperty(property) {
+        const blocks = document.getElementsByTagName("calcite-flow-item");
+
+        for (i = 0; i < blocks.length; i++) {
+          blocks[i].toggleAttribute(property);
+        }
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** #407 
flow item demo updated with loading and disabled states, Alan made styling changes to panel to accommodate those toggles.

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
