### PR TITLE
Bug: calcite-flow-item shows header-trailing-content without having menu-actions

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
+++ b/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
@@ -21,6 +21,30 @@ describe("calcite-flow-item", () => {
     expect(singleActionContainer).toBeNull();
   });
 
+  it("should not render containers when there are no menu actions in parent element", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+    <calcite-flow-item>
+      <div slot="footer-actions">
+        <div slot="menu-actions">
+          <button>Save</button>
+          <button>Cancel</button>
+        </div>
+        <button>Save</button>
+        <button>Cancel</button>
+      </div>
+    </calcite-flow-item>
+  `);
+
+    const menuContainer = await page.find(`calcite-flow-item >>> .${CSS.menuContainer}`);
+
+    const singleActionContainer = await page.find(`calcite-flow-item >>> .${CSS.singleActionContainer}`);
+
+    expect(menuContainer).toBeNull();
+    expect(singleActionContainer).toBeNull();
+  });
+
   it("should show single action container when one action exists", async () => {
     const page = await newE2EPage();
 

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -178,7 +178,7 @@ export class CalciteFlowItem {
 
   renderHeaderActions() {
     const menuActionsNode = this.el.querySelector("[slot=menu-actions]");
-    const hasMenuActions = !!menuActionsNode;
+    const hasMenuActions = !!menuActionsNode && menuActionsNode.parentElement === this.el;
     const actionCount = hasMenuActions ? menuActionsNode.childElementCount : 0;
 
     const menuActionsNodes =


### PR DESCRIPTION
**Related Issue:** Bug: calcite-flow-item shows header-trailing-content without having menu-actions #409

## Summary

Fixes an issue where the slot for menu actions isn't defined in the root but in another component which affects the rendering of the 3 dots icon showing when it shouldn't be showing.

See #409.

Fixed by making sure the slot is within the root of the element.

