### PR TITLE
#398 fix tip background color

### DIFF
--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -7,9 +7,11 @@ $tip-image-max-width: 100% !default;
   position: relative;
   display: flex;
   flex-flow: column;
+  background-color: transparent;
 }
 
 .container {
+  background-color: var(--calcite-app-background);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing) var(--calcite-app-cap-spacing);
   margin: var(--calcite-app-cap-spacing) var(--calcite-app-side-spacing);
   box-shadow: var(--calcite-app-shadow-2);


### PR DESCRIPTION
**Related Issue:** #398 fix tip background color.

## Summary

#398 fix tip background color.

The calcite-tip has a shadow inside of itself. The shadow should be either on the host or the background color should be defined where the shadow is.