### PR TITLE
bug(value-list): nixed disabled prop from destruct

### DIFF
--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -11,10 +11,8 @@ import {
   h
 } from "@stencil/core";
 import { checkSquare16, circle16, circleFilled16, drag16, square16 } from "@esri/calcite-ui-icons";
-import classnames from "classnames";
 import { CSS } from "./resources";
 import { ICON_TYPES } from "../calcite-pick-list/resources";
-import { CSS_UTILITY } from "../utils/resources";
 import CalciteIcon from "../utils/CalciteIcon";
 
 @Component({

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -283,7 +283,7 @@ export class CalciteValueList {
   }
 
   render() {
-    const { dataForFilter, handleFilter, disabled, filterEnabled, loading } = this;
+    const { dataForFilter, handleFilter, filterEnabled, loading } = this;
     return (
       <Host>
         <div class={CSS.container} aria-busy={loading}>


### PR DESCRIPTION
**Related Issue:** ##424

## Summary
Removed unused `disabled` from descruture.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
