### PR TITLE
fix(value-list-item): removed redundant padding

### DIFF
--- a/src/components/calcite-value-list-item/calcite-value-list-item.scss
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.scss
@@ -6,8 +6,6 @@
 calcite-pick-list-item {
   border-radius: var(--calcite-app-border-radius);
   box-shadow: none;
-  padding-top: var(--calcite-app-side-spacing-three-quarters);
-  padding-bottom: var(--calcite-app-side-spacing-three-quarters);
   position: relative;
   margin: 0 0 var(--calcite-app-cap-spacing-eighth) 0;
   transition: background-color var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function),


### PR DESCRIPTION
**Related Issue:** #456

## Summary
Remove redundant padding.
This PR refrains from some needed styling that is coming in #458 

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
