### PR TITLE
Issue #404: Add icon slot for calcite block header .

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -132,7 +132,9 @@ describe("calcite-block", () => {
 
       const icon = await page.find(`.header-icon`);
       expect(await icon.isVisible()).toBe(true);
-      expect(await icon.getProperty("slot")).toEqual(SLOTS.icon);
+
+      const iconSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.icon}]`);
+      expect(await iconSlot.isVisible()).toBe(true);
     });
   });
 });

--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { CSS, TEXT } from "./resources";
+import { CSS, SLOTS, TEXT } from "./resources";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-block", () => {
@@ -21,11 +21,12 @@ describe("calcite-block", () => {
 
   it("is accessible", async () =>
     accessible(`
-    <calcite-block heading="heading" summary="summary" open collapsible>
-      <div>content</div>
-      <label slot="control">test <input placeholder="control"/></label>
-    </calcite-block>
-`));
+      <calcite-block heading="heading" summary="summary" open collapsible>
+        <div  slot=${SLOTS.icon}>✅</div>
+        <div>content</div>
+        <label slot=${SLOTS.control}>test <input placeholder="control"/></label>
+      </calcite-block>
+  `));
 
   it("can display/hide content", async () => {
     const page = await newE2EPage();
@@ -106,13 +107,14 @@ describe("calcite-block", () => {
     it("supports a nested control", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-block heading="test-heading" collapsible><input class="nested-control" slot="control" /></calcite-block>`
+        `<calcite-block heading="test-heading" collapsible><input class="nested-control" slot=${SLOTS.control} /></calcite-block>`
       );
       const element = await page.find("calcite-block");
       const elementToggleSpy = await element.spyOnEvent("calciteBlockToggle");
 
       const control = await element.find(".nested-control");
       expect(await control.isVisible()).toBe(true);
+      expect(await control.getProperty("slot")).toEqual(SLOTS.control);
 
       await control.click();
       expect(elementToggleSpy).toHaveReceivedEventTimes(0);
@@ -120,6 +122,17 @@ describe("calcite-block", () => {
       await element.click();
       await element.click();
       expect(elementToggleSpy).toHaveReceivedEventTimes(2);
+    });
+
+    it("supports a header icon", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-block heading="test-heading"><div class="header-icon" slot=${SLOTS.icon} /></calcite-block>`
+      );
+
+      const icon = await page.find(`.header-icon`);
+      expect(await icon.isVisible()).toBe(true);
+      expect(await icon.getProperty("slot")).toEqual(SLOTS.icon);
     });
   });
 });

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -25,6 +25,7 @@ calcite-loader[inline] {
 }
 
 .title {
+  flex-grow: 1;
   margin: 0;
 }
 

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,13 +1,12 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
 import { chevronDown16, chevronUp16 } from "@esri/calcite-ui-icons";
-import { CSS, TEXT } from "./resources";
+import { CSS, SLOTS, TEXT } from "./resources";
 import CalciteIcon from "../utils/CalciteIcon";
 import { CalciteTheme } from "../interfaces";
 import CalciteScrim from "../utils/CalciteScrim";
 
-const CONTROL_SLOT_NAME = "control";
-
 /**
+ * @slot icon - A slot for adding a trailing header icon.
  * @slot control - A slot for adding a single HTML input element in a header.
  */
 @Component({
@@ -103,7 +102,7 @@ export class CalciteBlock {
 
   onHeaderClick = (event: MouseEvent) => {
     const controlSlot = this.el.shadowRoot.querySelector<HTMLSlotElement>(
-      `slot[name=${CONTROL_SLOT_NAME}]`
+      `slot[name=${SLOTS.control}]`
     );
     const control = controlSlot && controlSlot.assignedNodes()[0];
 
@@ -139,11 +138,12 @@ export class CalciteBlock {
     const content = loading ? (
       <calcite-loader inline is-active></calcite-loader>
     ) : !disabled ? (
-      <slot name={CONTROL_SLOT_NAME} />
+      <slot name={SLOTS.control} />
     ) : null;
 
     const headerContent = (
       <header class={CSS.header}>
+        <slot name={SLOTS.icon} />
         <div class={CSS.title}>
           <h3 class={CSS.heading}>{heading}</h3>
           {summary ? <div class={CSS.summary}>{summary}</div> : null}
@@ -174,7 +174,7 @@ export class CalciteBlock {
       </div>
     );
 
-    const hasContent = !!Array.from(el.children).some((child) => child.slot !== CONTROL_SLOT_NAME);
+    const hasContent = !!Array.from(el.children).some((child) => child.slot !== SLOTS.control);
 
     return (
       <Host>

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -15,3 +15,8 @@ export const TEXT = {
   collapse: "Collapse",
   expand: "Expand"
 };
+
+export const enum SLOTS {
+  icon = "icon",
+  control = "control"
+}

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -43,7 +43,7 @@
         <h2>Header + control</h2>
 
         <calcite-block heading="With control" summary="has inline input">
-          <label slot="control">test</label>
+          <label slot="control">test <input placeholder="I'm a header control"/></label>
         </calcite-block>
 
         <h2>Icon + Header</h2>

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -43,7 +43,13 @@
         <h2>Header + control</h2>
 
         <calcite-block heading="With control" summary="has inline input">
-          <label slot="control">test <input placeholder="I'm a header control"/></label>
+          <label slot="control">test</label>
+        </calcite-block>
+
+        <h2>Icon + Header</h2>
+
+        <calcite-block heading="Icon on header">
+          <div slot="icon">✅</div>
         </calcite-block>
 
         <h2>Header + content (collapsible)</h2>


### PR DESCRIPTION
**Related Issue:** #404

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Adds slot (name => `"icon"`) for trailing header icon.

@asangma Can you review the spacing between the icon and header? It may need some tweaking.