### PR TITLE
Fixed block caret icon size change when title is long.

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -49,8 +49,9 @@ calcite-loader[inline] {
 }
 
 .toggle-icon {
-  margin: 0 4px;
   fill: currentColor;
+  flex: 0 0 var(--calcite-app-icon-size);
+  margin: 0 var(--calcite-app-side-spacing-half);
 }
 
 .content {


### PR DESCRIPTION
**Related Issue:** #453

## Summary
Fixed block caret icon size change when title is long.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

