### PR TITLE
feat(pick-list-item): Exclude text-description in compact mode.

### DIFF
--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.scss
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.scss
@@ -33,7 +33,7 @@
 .label {
   display: flex;
   flex: 1 0 0;
-  padding: var(--calcite-app-cap-spacing) var(--calcite-app-side-spacing-half);
+  padding: var(--calcite-app-cap-spacing-three-quarters) var(--calcite-app-side-spacing-half);
   align-items: center;
   cursor: pointer;
 }
@@ -61,7 +61,7 @@
 .action {
   flex: 0 0 0%;
   justify-self: flex-end;
-  margin: 0 var(--calcite-app-side-spacing-half);
+  margin: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-half);
 }
 
 .handle {

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -193,9 +193,10 @@ export class CalcitePickListItem {
   }
 
   render() {
-    const description = this.textDescription ? (
-      <span class={CSS.description}>{this.textDescription}</span>
-    ) : null;
+    const description =
+      this.textDescription && !this.compact ? (
+        <span class={CSS.description}>{this.textDescription}</span>
+      ) : null;
 
     return (
       <Host selected={this.isSelected}>


### PR DESCRIPTION
**Related Issue:** #447

## Summary
text-description is not rendered in compact mode.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
