### PR TITLE
Issue #403: Hide collapsible icon when control is provided.

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -104,24 +104,47 @@ describe("calcite-block", () => {
       expect(summary.innerText).toBe("test-summary");
     });
 
-    it("supports a nested control", async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        `<calcite-block heading="test-heading" collapsible><input class="nested-control" slot=${SLOTS.control} /></calcite-block>`
-      );
-      const element = await page.find("calcite-block");
-      const elementToggleSpy = await element.spyOnEvent("calciteBlockToggle");
+    describe("adding a header control", () => {
+      it("allows users to add a control in a collapsible block", async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          `<calcite-block heading="test-heading" collapsible><input class="nested-control" slot=${SLOTS.control} /></calcite-block>`
+        );
+        const control = await page.find(".nested-control");
+        expect(await control.isVisible()).toBe(true);
 
-      const control = await element.find(".nested-control");
-      expect(await control.isVisible()).toBe(true);
-      expect(await control.getProperty("slot")).toEqual(SLOTS.control);
+        const controlSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.control}]`);
+        expect(await controlSlot.isVisible()).toBe(true);
 
-      await control.click();
-      expect(elementToggleSpy).toHaveReceivedEventTimes(0);
+        const collapsibleIcon = await page.find(`calcite-block >>> .${CSS.toggleIcon}`);
+        expect(collapsibleIcon).toBeNull();
 
-      await element.click();
-      await element.click();
-      expect(elementToggleSpy).toHaveReceivedEventTimes(2);
+        const block = await page.find("calcite-block");
+        const blockToggleSpy = await block.spyOnEvent("calciteBlockToggle");
+
+        expect(await control.isVisible()).toBe(true);
+        expect(await control.getProperty("slot")).toEqual(SLOTS.control);
+
+        await control.click();
+        expect(blockToggleSpy).toHaveReceivedEventTimes(0);
+
+        await block.click();
+        await block.click();
+        expect(blockToggleSpy).toHaveReceivedEventTimes(2);
+      });
+
+      it("allows users to add a control in a non-collapsible block", async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          `<calcite-block heading="test-heading"><input class="nested-control" slot=${SLOTS.control} /></calcite-block>`
+        );
+
+        const control = await page.find(".nested-control");
+        expect(await control.isVisible()).toBe(true);
+
+        const controlSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.control}]`);
+        expect(await controlSlot.isVisible()).toBe(true);
+      });
     });
 
     it("supports a header icon", async () => {

--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -104,47 +104,29 @@ describe("calcite-block", () => {
       expect(summary.innerText).toBe("test-summary");
     });
 
-    describe("adding a header control", () => {
-      it("allows users to add a control in a collapsible block", async () => {
-        const page = await newE2EPage();
-        await page.setContent(
-          `<calcite-block heading="test-heading" collapsible><input class="nested-control" slot=${SLOTS.control} /></calcite-block>`
-        );
-        const control = await page.find(".nested-control");
-        expect(await control.isVisible()).toBe(true);
+    it("allows users to add a control in a collapsible block", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-block heading="test-heading" collapsible><input class="nested-control" slot=${SLOTS.control} /></calcite-block>`
+      );
+      const control = await page.find(".nested-control");
+      expect(await control.isVisible()).toBe(true);
 
-        const controlSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.control}]`);
-        expect(await controlSlot.isVisible()).toBe(true);
+      const controlSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.control}]`);
+      expect(await controlSlot.isVisible()).toBe(true);
 
-        const collapsibleIcon = await page.find(`calcite-block >>> .${CSS.toggleIcon}`);
-        expect(collapsibleIcon).toBeNull();
+      const collapsibleIcon = await page.find(`calcite-block >>> .${CSS.toggleIcon}`);
+      expect(collapsibleIcon).toBeNull();
 
-        const block = await page.find("calcite-block");
-        const blockToggleSpy = await block.spyOnEvent("calciteBlockToggle");
+      const block = await page.find("calcite-block");
+      const blockToggleSpy = await block.spyOnEvent("calciteBlockToggle");
 
-        expect(await control.isVisible()).toBe(true);
-        expect(await control.getProperty("slot")).toEqual(SLOTS.control);
+      await control.click();
+      expect(blockToggleSpy).toHaveReceivedEventTimes(0);
 
-        await control.click();
-        expect(blockToggleSpy).toHaveReceivedEventTimes(0);
-
-        await block.click();
-        await block.click();
-        expect(blockToggleSpy).toHaveReceivedEventTimes(2);
-      });
-
-      it("allows users to add a control in a non-collapsible block", async () => {
-        const page = await newE2EPage();
-        await page.setContent(
-          `<calcite-block heading="test-heading"><input class="nested-control" slot=${SLOTS.control} /></calcite-block>`
-        );
-
-        const control = await page.find(".nested-control");
-        expect(await control.isVisible()).toBe(true);
-
-        const controlSlot = await page.find(`calcite-block >>> slot[name=${SLOTS.control}]`);
-        expect(await controlSlot.isVisible()).toBe(true);
-      });
+      await block.click();
+      await block.click();
+      expect(blockToggleSpy).toHaveReceivedEventTimes(2);
     });
 
     it("supports a header icon", async () => {

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -153,12 +153,13 @@ export class CalciteBlock {
     );
 
     let hasControl = false;
-    const hasContent = Array.from(el.children).some((child) => {
-      const isControl = child.slot === SLOTS.control;
-      hasControl = hasControl || isControl;
+    let hasContent = false;
 
-      return !isControl;
-    });
+    for (let i = 0; i < el.children.length; i++) {
+      const isControl = el.children[i].slot === SLOTS.control;
+      hasControl = hasControl || isControl;
+      hasContent = hasContent || !isControl;
+    }
 
     const headerNode = (
       <div class={CSS.headerContainer}>

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -152,6 +152,14 @@ export class CalciteBlock {
       </header>
     );
 
+    let hasControl = false;
+    const hasContent = Array.from(el.children).some((child) => {
+      const isControl = child.slot === SLOTS.control;
+      hasControl = hasControl || isControl;
+
+      return !isControl;
+    });
+
     const headerNode = (
       <div class={CSS.headerContainer}>
         {collapsible ? (
@@ -162,19 +170,19 @@ export class CalciteBlock {
             title={toggleLabel}
           >
             {headerContent}
-            <CalciteIcon
-              size="16"
-              path={open ? chevronUp16 : chevronDown16}
-              svgAttributes={{ class: CSS.toggleIcon }}
-            />
+            {hasControl ? null : (
+              <CalciteIcon
+                size="16"
+                path={open ? chevronUp16 : chevronDown16}
+                svgAttributes={{ class: CSS.toggleIcon }}
+              />
+            )}
           </button>
         ) : (
           headerContent
         )}
       </div>
     );
-
-    const hasContent = !!Array.from(el.children).some((child) => child.slot !== SLOTS.control);
 
     return (
       <Host>

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -149,7 +149,7 @@
 
         <h2>Header + collapsible + control = no collapsible icon</h2>
 
-        <calcite-block heading="no control if block is collapsible" collapsible>
+        <calcite-block heading="no toggle icon when there is a control" collapsible>
           <label slot="control">test</label>
           <div>Some content</div>
         </calcite-block>

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -52,6 +52,12 @@
           <div slot="icon">✅</div>
         </calcite-block>
 
+        <h2>Header + content (always open)</h2>
+
+        <calcite-block heading="Header" open>
+          <div>Some content</div>
+        </calcite-block>
+
         <h2>Header + content (collapsible)</h2>
 
         <calcite-block heading="All the king's buff horses couldn't fix the turbo." summary="summary" open collapsible>
@@ -139,6 +145,13 @@
               <input type="text" />
             </label>
           </calcite-block-section>
+        </calcite-block>
+
+        <h2>Header + collapsible + control = no collapsible icon</h2>
+
+        <calcite-block heading="no control if block is collapsible" collapsible>
+          <label slot="control">test</label>
+          <div>Some content</div>
         </calcite-block>
 
         <h2>RTL</h2>


### PR DESCRIPTION
**Related Issue:** #403

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This hides the collapsible icon (downward/upward chevron) whenever there is a control.
