### PR TITLE
PickList and ValueList: share more code between lists 461

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ Thumbs.db
 UserInterfaceState.xcuserstate
 .env
 src/**/components.d.ts
+
+# backup files
+*.bak
+*.orig

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -28,6 +28,11 @@ export class CalcitePickListItem {
   // --------------------------------------------------------------------------
 
   /**
+   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute. This allows for a more compact version of the pick-list-item.
+   */
+  @Prop({ reflect: true }) compact = false;
+
+  /**
    * When true, the item cannot be clicked and is visually muted.
    */
   @Prop({ reflect: true }) disabled = false;
@@ -50,11 +55,6 @@ export class CalcitePickListItem {
    * Set this to true to pre-select an item. Toggles when an item is checked/unchecked.
    */
   @Prop() selected = false;
-
-  /**
-   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute. This allows for a more compact version of the pick-list-item.
-   */
-  @Prop({ reflect: true }) compact = false;
 
   @Watch("selected")
   selectedWatchHandler(newValue) {

--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -1,14 +1,16 @@
-import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { newE2EPage } from "@stencil/core/testing";
 import { ICON_TYPES } from "./resources";
 import { hidden, renders } from "../../tests/commonTests";
-import tests from "./shared-list-tests";
+import { tests } from "./shared-list-tests";
+
+const { selectionAndDeselection, filterBehavior, disabledStates } = tests;
 
 describe("calcite-pick-list", () => {
   it("renders", async () => renders("calcite-pick-list"));
   it("honors hidden attribute", async () => hidden("calcite-pick-list"));
 
   describe("Selection and Deselection", () => {
-    tests.selectionAndDeselection("pick");
+    selectionAndDeselection("pick");
   });
 
   describe("icon logic", () => {
@@ -35,10 +37,10 @@ describe("calcite-pick-list", () => {
   });
 
   describe("filter behavior (hide/show items)", () => {
-    tests.filterBehavior("pick");
+    filterBehavior("pick");
   });
 
   describe("disabled states", () => {
-    tests.disabledStates("pick");
+    disabledStates("pick");
   });
 });

--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -1,73 +1,14 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { ICON_TYPES } from "./resources";
+import { hidden, renders } from "../../tests/commonTests";
+import tests from "./shared-list-tests";
 
 describe("calcite-pick-list", () => {
-  it("should render", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`<calcite-pick-list></calcite-pick-list>`);
-    const pickList = await page.find("calcite-pick-list");
-    expect(pickList).not.toBeNull();
-    const isVisible = await pickList.isVisible();
-    expect(isVisible).toBe(true);
-  });
+  it("renders", async () => renders("calcite-pick-list"));
+  it("honors hidden attribute", async () => hidden("calcite-pick-list"));
 
   describe("Selection and Deselection", () => {
-    describe("when multiple is false and a item is clicked", () => {
-      it("should emit an event with the last selected item data", async () => {
-        const page = await newE2EPage();
-        await page.setContent(`<calcite-pick-list>
-          <calcite-pick-list-item value="one"></calcite-pick-list-item>
-          <calcite-pick-list-item value="two"></calcite-pick-list-item>
-        </calcite-pick-list>`);
-
-        const pickList = await page.find("calcite-pick-list");
-        const item1 = await pickList.find("[value=one]");
-        const item2 = await pickList.find("[value=two]");
-        const toggleSpy = await pickList.spyOnEvent("calciteListChange");
-
-        await item1.click();
-        await item2.click();
-        expect(toggleSpy).toHaveReceivedEventTimes(2);
-      });
-    });
-    describe("when multiple is true and a item is clicked", () => {
-      it("should emit an event with each selected item's data", async () => {
-        const page = await newE2EPage();
-        await page.setContent(`<calcite-pick-list multiple>
-          <calcite-pick-list-item value="one"></calcite-pick-list-item>
-          <calcite-pick-list-item value="two"></calcite-pick-list-item>
-        </calcite-pick-list>`);
-
-        const pickList = await page.find("calcite-pick-list");
-        const item1 = await pickList.find("[value=one]");
-        const item2 = await pickList.find("[value=two]");
-        const toggleSpy = await pickList.spyOnEvent("calciteListChange");
-
-        await item1.click();
-        await item2.click();
-        await item2.click(); // deselect
-        expect(toggleSpy).toHaveReceivedEventTimes(3);
-      });
-    });
-    describe("preselected items", () => {
-      it("should be included in the list of selected items", async () => {
-        const page = await newE2EPage();
-        await page.setContent(`<calcite-pick-list multiple>
-          <calcite-pick-list-item value="one" selected></calcite-pick-list-item>
-          <calcite-pick-list-item value="two"></calcite-pick-list-item>
-        </calcite-pick-list>`);
-
-        const numSelected = await page.evaluate(() => {
-          const pickList = document.querySelector("calcite-pick-list");
-          return pickList.getSelectedItems().then((result) => {
-            return result.size;
-          });
-        });
-
-        expect(numSelected).toBe(1);
-      });
-    });
+    tests.selectionAndDeselection("pick");
     // TODO: shift click test
     // describe.skip("shift click behavior", () => {
     //   it("should multi-select", async () => {

--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -106,7 +106,7 @@ describe("calcite-pick-list", () => {
   //   it("loading", async () => {
   //   });
   // });
-  describe.only("filter behavior (hide/show items)", () => {
+  describe("filter behavior (hide/show items)", () => {
     let page: E2EPage = null;
     let item1: E2EElement;
     let item2: E2EElement;

--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -9,12 +9,6 @@ describe("calcite-pick-list", () => {
 
   describe("Selection and Deselection", () => {
     tests.selectionAndDeselection("pick");
-    // TODO: shift click test
-    // describe.skip("shift click behavior", () => {
-    //   it("should multi-select", async () => {
-
-    //   });
-    // });
   });
 
   describe("icon logic", () => {
@@ -40,116 +34,11 @@ describe("calcite-pick-list", () => {
     });
   });
 
-  // TODO: disabled state tests.
-  // describe.skip('disabled states', () => {
-  //   it("disabled", async () => {
-  //   });
-  //   it("loading", async () => {
-  //   });
-  // });
   describe("filter behavior (hide/show items)", () => {
-    let page: E2EPage = null;
-    let item1: E2EElement;
-    let item2: E2EElement;
-    let item1Visible;
-    let item2Visible;
-    beforeEach(async () => {
-      page = await newE2EPage();
-      await page.setContent(`<calcite-pick-list filter-enabled="true">
-        <calcite-pick-list-item value="1" text-label="One" text-description="uno"></calcite-pick-list-item>
-        <calcite-pick-list-item value="2" text-label="Two" text-description="dos"></calcite-pick-list-item>
-      </calcite-pick-list>`);
-      item1 = await page.find('calcite-pick-list-item[value="1"]');
-      item2 = await page.find('calcite-pick-list-item[value="2"]');
-      item1.setProperty("metadata", { category: "first" });
-      item2.setProperty("metadata", { category: "second" });
-      await page.waitForChanges();
-      await page.evaluate(() => {
-        (window as any).filter = document.querySelector("calcite-pick-list").shadowRoot.querySelector("calcite-filter");
-        const filter = (window as any).filter;
-        (window as any).filterInput = filter.shadowRoot.querySelector("input");
-      });
-    });
-    it("should match text in the text-label prop", async () => {
-      // Match first item
-      await page.evaluate(() => {
-        const filterInput = (window as any).filterInput;
-        filterInput.value = "one";
-        filterInput.dispatchEvent(new Event("input"));
-      });
-      await item2.waitForNotVisible();
+    tests.filterBehavior("pick");
+  });
 
-      item1Visible = await item1.isVisible();
-      item2Visible = await item2.isVisible();
-
-      expect(item1Visible).toBe(true);
-      expect(item2Visible).toBe(false);
-
-      // Match second item
-      await page.evaluate(() => {
-        const filterInput = (window as any).filterInput;
-        filterInput.value = "two";
-        filterInput.dispatchEvent(new Event("input"));
-      });
-      await item1.waitForNotVisible();
-
-      item1Visible = await item1.isVisible();
-      item2Visible = await item2.isVisible();
-      expect(item1Visible).toBe(false);
-      expect(item2Visible).toBe(true);
-    });
-    it("should match text in the text-description prop", async () => {
-      // Match first item
-      await page.evaluate(() => {
-        const filterInput = (window as any).filterInput;
-        filterInput.value = "uno";
-        filterInput.dispatchEvent(new Event("input"));
-      });
-      await item2.waitForNotVisible();
-
-      item1Visible = await item1.isVisible();
-      item2Visible = await item2.isVisible();
-
-      expect(item1Visible).toBe(true);
-      expect(item2Visible).toBe(false);
-
-      // Match second item
-      await page.evaluate(() => {
-        const filterInput = (window as any).filterInput;
-        filterInput.value = "dos";
-        filterInput.dispatchEvent(new Event("input"));
-      });
-      await item1.waitForNotVisible();
-
-      item1Visible = await item1.isVisible();
-      item2Visible = await item2.isVisible();
-      expect(item1Visible).toBe(false);
-      expect(item2Visible).toBe(true);
-    });
-    it("should match text in the metadata prop", async () => {
-      await page.evaluate(() => {
-        const filterInput = (window as any).filterInput;
-        filterInput.value = "first";
-        filterInput.dispatchEvent(new Event("input"));
-      });
-      await item2.waitForNotVisible();
-
-      let item1Visible = await item1.isVisible();
-      let item2Visible = await item2.isVisible();
-      expect(item1Visible).toBe(true);
-      expect(item2Visible).toBe(false);
-
-      await page.evaluate(() => {
-        const filterInput = (window as any).filterInput;
-        filterInput.value = "second";
-        filterInput.dispatchEvent(new Event("input"));
-      });
-      await item1.waitForNotVisible();
-
-      item1Visible = await item1.isVisible();
-      item2Visible = await item2.isVisible();
-      expect(item1Visible).toBe(false);
-      expect(item2Visible).toBe(true);
-    });
+  describe("disabled states", () => {
+    tests.disabledStates("pick");
   });
 });

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -198,16 +198,16 @@ export class CalcitePickList {
   }
 
   render() {
-    const { disabled, loading } = this;
+    const { dataForFilter, handleFilter, filterEnabled, loading, disabled } = this;
     return (
       <Host aria-disabled={disabled} aria-busy={loading}>
         <header>
-          {this.filterEnabled ? (
+          {filterEnabled ? (
             <calcite-filter
-              data={this.dataForFilter}
+              data={dataForFilter}
               textPlaceholder={TEXT.filterPlaceholder}
               aria-label={TEXT.filterPlaceholder}
-              onCalciteFilterChange={this.handleFilter}
+              onCalciteFilterChange={handleFilter}
             />
           ) : null}
           <slot name="menu-actions" />

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -87,10 +87,7 @@ export class CalcitePickList {
 
   lastSelectedItem: HTMLCalcitePickListItemElement = null;
 
-  observer = new MutationObserver(() => {
-    this.setUpItems();
-    this.setUpFilter();
-  });
+  observer = new MutationObserver(sharedListMethods.mutationObserverCallback.bind(this));
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -11,9 +11,22 @@ import {
   h
 } from "@stencil/core";
 import { ICON_TYPES, TEXT } from "./resources";
-import sharedListMethods from "./shared-list-logic";
+import { sharedListMethods } from "./shared-list-logic";
 import { VNode } from "@stencil/core/dist/declarations";
 import CalciteScrim from "../utils/CalciteScrim";
+
+const {
+  mutationObserverCallback,
+  initialize,
+  initializeObserver,
+  cleanUpObserver,
+  calciteListItemChangeHandler,
+  setUpItems,
+  deselectSiblingItems,
+  selectSiblings,
+  handleFilter,
+  getItemData
+} = sharedListMethods;
 
 /**
  * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
@@ -87,13 +100,7 @@ export class CalcitePickList {
 
   lastSelectedItem: HTMLCalcitePickListItemElement = null;
 
-  observer = new MutationObserver(sharedListMethods.mutationObserverCallback.bind(this));
-
-  // --------------------------------------------------------------------------
-  //
-  //  Private Properties
-  //
-  // --------------------------------------------------------------------------
+  observer = new MutationObserver(mutationObserverCallback.bind(this));
 
   @Element() el: HTMLCalcitePickListElement;
 
@@ -104,15 +111,15 @@ export class CalcitePickList {
   // --------------------------------------------------------------------------
 
   connectedCallback() {
-    sharedListMethods.initialize.call(this);
+    initialize.call(this);
   }
 
   componentDidLoad() {
-    sharedListMethods.initializeObserver.call(this);
+    initializeObserver.call(this);
   }
 
   componentDidUnload() {
-    sharedListMethods.cleanUpObserver.call(this);
+    cleanUpObserver.call(this);
   }
 
   // --------------------------------------------------------------------------
@@ -134,7 +141,7 @@ export class CalcitePickList {
   @Event() calcitePickListSelectionChange: EventEmitter;
 
   @Listen("calciteListItemChange") calciteListItemChangeHandler(event: CustomEvent) {
-    sharedListMethods.calciteListItemChangeHandler.call(this, event);
+    calciteListItemChangeHandler.call(this, event);
     this.calcitePickListSelectionChange.emit(this.selectedValues);
   }
 
@@ -149,7 +156,7 @@ export class CalcitePickList {
   // --------------------------------------------------------------------------
 
   setUpItems(): void {
-    sharedListMethods.setUpItems.call(this, "calcite-pick-list-item");
+    setUpItems.call(this, "calcite-pick-list-item");
   }
 
   setUpFilter(): void {
@@ -158,13 +165,13 @@ export class CalcitePickList {
     }
   }
 
-  deselectSiblingItems = sharedListMethods.deselectSiblingItems.bind(this);
+  deselectSiblingItems = deselectSiblingItems.bind(this);
 
-  selectSiblings = sharedListMethods.selectSiblings.bind(this);
+  selectSiblings = selectSiblings.bind(this);
 
-  handleFilter = sharedListMethods.handleFilter.bind(this);
+  handleFilter = handleFilter.bind(this);
 
-  getItemData = sharedListMethods.getItemData.bind(this);
+  getItemData = getItemData.bind(this);
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -133,8 +133,9 @@ export class CalcitePickList {
    */
   @Event() calcitePickListSelectionChange: EventEmitter;
 
-  @Listen("calciteListItemChange") calciteListItemChangeHandler(event) {
+  @Listen("calciteListItemChange") calciteListItemChangeHandler(event: CustomEvent) {
     sharedListMethods.calciteListItemChangeHandler.call(this, event);
+    this.calcitePickListSelectionChange.emit(this.selectedValues);
   }
 
   @Listen("calciteListItemPropsUpdated") calciteListItemPropsUpdatedHandler() {

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -61,7 +61,7 @@ export class CalcitePickList {
    */
   @Prop({ reflect: true }) mode: "selection" | "configuration" = "selection";
   /**
-   * Multiple Works similar to standard radio buttons and checkboxes.
+   * Multiple works similar to standard radio buttons and checkboxes.
    * When true, a user can select multiple items at a time.
    * When false, only a single item can be selected at a time
    * and selecting a new item will deselect any other selected items.

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -29,6 +29,13 @@ export class CalcitePickList {
   //  Properties
   //
   // --------------------------------------------------------------------------
+
+  /**
+   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute.
+   * This allows for a more compact version of the pick-list-item.
+   */
+  @Prop({ reflect: true }) compact = false;
+
   /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
    */
@@ -60,12 +67,6 @@ export class CalcitePickList {
    * and selecting a new item will deselect any other selected items.
    */
   @Prop({ reflect: true }) multiple = false;
-
-  /**
-   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute.
-   * This allows for a more compact version of the pick-list-item.
-   */
-  @Prop({ reflect: true }) compact = false;
 
   /**
    * @deprecated No longer rendered. Prop will be removed in a future release.

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -33,7 +33,7 @@ export const sharedListMethods = {
     this.observer.disconnect();
   },
   // Listeners
-  calciteListItemChangeHandler(this: CalcitePickList | CalciteValueList, event): void {
+  calciteListItemChangeHandler(this: CalcitePickList | CalciteValueList, event: CustomEvent): void {
     const { selectedValues } = this;
     const { item, value, selected, shiftPressed } = event.detail;
     if (selected) {
@@ -49,7 +49,6 @@ export const sharedListMethods = {
     }
     this.lastSelectedItem = item;
     this.calciteListChange.emit(selectedValues);
-    // this.calcitePickListSelectionChange.emit(selectedValues); picklist only
   },
   // Private Methods
   setUpItems(

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -107,9 +107,10 @@ export const sharedListMethods = {
   },
   getItemData(this: CalcitePickList | CalciteValueList): Record<string, string | object>[] {
     const result: Record<string, string | object>[] = [];
-    this.items.forEach((item) => {
+    this.items.forEach((item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
       const obj: Record<string, string | object> = {};
-      obj.label = item.textLabel || item.textHeading;
+      const textHeading = "textHeading" in item ? item.textHeading : "";
+      obj.label = item.textLabel || textHeading;
       obj.description = item.textDescription;
       obj.metadata = item.metadata;
       obj.value = item.value;

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -1,6 +1,21 @@
 import { CalcitePickList } from "./calcite-pick-list";
 import { CalciteValueList } from "../calcite-value-list/calcite-value-list";
 
+function updateSelectedValuesMap(
+  selectedValuesMap: Map<string, HTMLCalcitePickListItemElement> | Map<string, HTMLCalciteValueListItemElement>,
+  item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
+) {
+  const selectedValues = (selectedValuesMap as any) as Map<
+    string,
+    HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
+  >;
+  if (selectedValues as Map<string, HTMLCalcitePickListItemElement>) {
+    selectedValues.set(item.value, item as HTMLCalcitePickListItemElement);
+  } else if (selectedValues as Map<string, HTMLCalciteValueListItemElement>) {
+    selectedValues.set(item.value, item as HTMLCalciteValueListItemElement);
+  }
+}
+
 export const sharedListMethods = {
   mutationObserverCallback(this: CalcitePickList | CalciteValueList) {
     this.setUpItems();
@@ -40,9 +55,12 @@ export const sharedListMethods = {
     // this.calcitePickListSelectionChange.emit(selectedValues); picklist only
   },
   // Private Methods
-  setUpItems(this: CalcitePickList | CalciteValueList, tagname): void {
+  setUpItems(
+    this: CalcitePickList | CalciteValueList,
+    tagname: "calcite-pick-list-item" | "calcite-pick-list-item"
+  ): void {
     this.items = Array.from(this.el.querySelectorAll(tagname));
-    this.items.forEach((item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
+    this.items.forEach((item) => {
       const iconType = this.getIconType();
       if (iconType) {
         item.setAttribute("icon", iconType);
@@ -51,7 +69,7 @@ export const sharedListMethods = {
       }
       item.compact = this.compact;
       if (item.hasAttribute("selected")) {
-        this.selectedValues.set(item.getAttribute("value"), item);
+        updateSelectedValuesMap(this.selectedValues, item);
       }
     });
   },
@@ -91,7 +109,7 @@ export const sharedListMethods = {
       .slice(Math.min(start, end), Math.max(start, end))
       .forEach((currentItem: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
         currentItem.toggleSelected(true);
-        this.selectedValues.set(currentItem.value, currentItem);
+        updateSelectedValuesMap(this.selectedValues, currentItem);
       });
   },
   handleFilter(this: CalcitePickList | CalciteValueList, event) {
@@ -109,8 +127,7 @@ export const sharedListMethods = {
     const result: Record<string, string | object>[] = [];
     this.items.forEach((item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
       const obj: Record<string, string | object> = {};
-      const textHeading = "textHeading" in item ? item.textHeading : "";
-      obj.label = item.textLabel || textHeading;
+      obj.label = item.textLabel || (item as HTMLCalcitePickListItemElement).textHeading;
       obj.description = item.textDescription;
       obj.metadata = item.metadata;
       obj.value = item.value;

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -1,0 +1,106 @@
+export const sharedListMethods = {
+  getObserver: new MutationObserver(() => {
+    this.setUpItems();
+    this.setUpFilter();
+  }),
+  // LifeCycle functions
+  initialize() {
+    // connectedCallback
+    this.setUpItems();
+    this.setUpFilter();
+  },
+  initializeObserver() {
+    // componentDidLoad
+    this.observer.observe(this.el, { childList: true, subtree: true });
+  },
+  cleanUpObserver() {
+    // componentDidUnload
+    this.observer.disconnect();
+  },
+  // Listeners
+  calciteListItemChangeHandler(event): void {
+    const { selectedValues } = this;
+    const { item, value, selected, shiftPressed } = event.detail;
+    if (selected) {
+      if (!this.multiple) {
+        this.deselectSiblingItems(item);
+      }
+      if (this.multiple && shiftPressed) {
+        this.selectSiblings(item);
+      }
+      selectedValues.set(value, item);
+    } else {
+      selectedValues.delete(value);
+    }
+    this.lastSelectedItem = item;
+    this.calciteListChange.emit(selectedValues);
+    // this.calcitePickListSelectionChange.emit(selectedValues); picklist only
+  },
+  // Private Methods
+  setUpItems(tagname): void {
+    this.items = Array.from(this.el.querySelectorAll(tagname));
+    this.items.forEach((item) => {
+      const iconType = this.getIconType();
+      if (iconType) {
+        item.setAttribute("icon", iconType);
+      } else {
+        item.removeAttribute("icon");
+      }
+      item.compact = this.compact; // only used by pickList but shouldn't hurt
+      if (item.hasAttribute("selected")) {
+        this.selectedValues.set(item.getAttribute("value"), item);
+      }
+    });
+  },
+  setUpFilter(): void {
+    if (this.filterEnabled) {
+      this.dataForFilter = this.getItemData();
+    }
+  },
+  deselectSiblingItems(item: HTMLCalcitePickListItemElement) {
+    this.items.forEach((currentItem) => {
+      if (currentItem !== item) {
+        currentItem.toggleSelected(false);
+        if (this.selectedValues.has(currentItem.value)) {
+          this.selectedValues.delete(currentItem.value);
+        }
+      }
+    });
+  },
+  selectSiblings(item: HTMLCalcitePickListItemElement) {
+    if (!this.lastSelectedItem) {
+      return;
+    }
+    const { items } = this;
+    const start = items.indexOf(this.lastSelectedItem);
+    const end = items.indexOf(item);
+    items.slice(Math.min(start, end), Math.max(start, end)).forEach((currentItem) => {
+      currentItem.toggleSelected(true);
+      this.selectedValues.set(currentItem.value, currentItem);
+    });
+  },
+  handleFilter(event) {
+    const filteredData = event.detail;
+    const values = filteredData.map((item) => item.value);
+    this.items.forEach((item) => {
+      if (values.indexOf(item.value) === -1) {
+        item.setAttribute("hidden", "");
+      } else {
+        item.removeAttribute("hidden");
+      }
+    });
+  },
+  getItemData(): Record<string, string | object>[] {
+    const result: Record<string, string | object>[] = [];
+    this.items.forEach((item) => {
+      const obj: Record<string, string | object> = {};
+      obj.label = item.textLabel || item.textHeading;
+      obj.description = item.textDescription;
+      obj.metadata = item.metadata;
+      obj.value = item.value;
+      result.push(obj);
+    });
+    return result;
+  }
+};
+export default sharedListMethods;

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -42,14 +42,14 @@ export const sharedListMethods = {
   // Private Methods
   setUpItems(this: CalcitePickList | CalciteValueList, tagname): void {
     this.items = Array.from(this.el.querySelectorAll(tagname));
-    this.items.forEach((item) => {
+    this.items.forEach((item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
       const iconType = this.getIconType();
       if (iconType) {
         item.setAttribute("icon", iconType);
       } else {
         item.removeAttribute("icon");
       }
-      item.compact = this.compact; // only used by pickList but shouldn't hurt
+      item.compact = this.compact;
       if (item.hasAttribute("selected")) {
         this.selectedValues.set(item.getAttribute("value"), item);
       }
@@ -60,7 +60,10 @@ export const sharedListMethods = {
       this.dataForFilter = this.getItemData();
     }
   },
-  deselectSiblingItems(this: CalcitePickList | CalciteValueList, item: HTMLCalcitePickListItemElement) {
+  deselectSiblingItems(
+    this: CalcitePickList | CalciteValueList,
+    item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
+  ) {
     this.items.forEach((currentItem) => {
       if (currentItem !== item) {
         currentItem.toggleSelected(false);
@@ -72,7 +75,7 @@ export const sharedListMethods = {
   },
   selectSiblings(
     this: CalcitePickList | CalciteValueList,
-    item: HTMLCalcitePickListItemElement | HTMLCalcitePickListItemElement
+    item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
   ) {
     if (!this.lastSelectedItem) {
       return;
@@ -84,10 +87,12 @@ export const sharedListMethods = {
     const end = items.findIndex((currentItem) => {
       return currentItem.value === item.value;
     });
-    items.slice(Math.min(start, end), Math.max(start, end)).forEach((currentItem) => {
-      currentItem.toggleSelected(true);
-      this.selectedValues.set(currentItem.value, currentItem);
-    });
+    items
+      .slice(Math.min(start, end), Math.max(start, end))
+      .forEach((currentItem: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
+        currentItem.toggleSelected(true);
+        this.selectedValues.set(currentItem.value, currentItem);
+      });
   },
   handleFilter(this: CalcitePickList | CalciteValueList, event) {
     const filteredData = event.detail;

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -4,7 +4,7 @@ import { CalciteValueList } from "../calcite-value-list/calcite-value-list";
 function updateSelectedValuesMap(
   selectedValuesMap: Map<string, HTMLCalcitePickListItemElement> | Map<string, HTMLCalciteValueListItemElement>,
   item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
-) {
+): void {
   const selectedValues = (selectedValuesMap as any) as Map<
     string,
     HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
@@ -17,19 +17,19 @@ function updateSelectedValuesMap(
 }
 
 export const sharedListMethods = {
-  mutationObserverCallback(this: CalcitePickList | CalciteValueList) {
+  mutationObserverCallback(this: CalcitePickList | CalciteValueList): void {
     this.setUpItems();
     this.setUpFilter();
   },
   // LifeCycle functions
-  initialize(this: CalcitePickList | CalciteValueList) {
+  initialize(this: CalcitePickList | CalciteValueList): void {
     this.setUpItems();
     this.setUpFilter();
   },
-  initializeObserver(this: CalcitePickList | CalciteValueList) {
+  initializeObserver(this: CalcitePickList | CalciteValueList): void {
     this.observer.observe(this.el, { childList: true, subtree: true });
   },
-  cleanUpObserver(this: CalcitePickList | CalciteValueList) {
+  cleanUpObserver(this: CalcitePickList | CalciteValueList): void {
     this.observer.disconnect();
   },
   // Listeners
@@ -108,7 +108,7 @@ export const sharedListMethods = {
         updateSelectedValuesMap(this.selectedValues, currentItem);
       });
   },
-  handleFilter(this: CalcitePickList | CalciteValueList, event) {
+  handleFilter(this: CalcitePickList | CalciteValueList, event: CustomEvent): void {
     const filteredData = event.detail;
     const values = filteredData.map((item) => item.value);
     this.items.forEach((item) => {

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -1,17 +1,18 @@
 import { CalcitePickList } from "./calcite-pick-list";
 import { CalciteValueList } from "../calcite-value-list/calcite-value-list";
 
+type pickListItemMap = Map<string, HTMLCalcitePickListItemElement>;
+type valueListItemMap = Map<string, HTMLCalciteValueListItemElement>;
+type pickOrValueListItem = HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement;
+
 function updateSelectedValuesMap(
-  selectedValuesMap: Map<string, HTMLCalcitePickListItemElement> | Map<string, HTMLCalciteValueListItemElement>,
-  item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
+  selectedValuesMap: pickListItemMap | valueListItemMap,
+  item: pickOrValueListItem
 ): void {
-  const selectedValues = (selectedValuesMap as any) as Map<
-    string,
-    HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
-  >;
-  if (selectedValues as Map<string, HTMLCalcitePickListItemElement>) {
+  const selectedValues = (selectedValuesMap as any) as Map<string, pickOrValueListItem>;
+  if (selectedValues as pickListItemMap) {
     selectedValues.set(item.value, item as HTMLCalcitePickListItemElement);
-  } else if (selectedValues as Map<string, HTMLCalciteValueListItemElement>) {
+  } else if (selectedValues as valueListItemMap) {
     selectedValues.set(item.value, item as HTMLCalciteValueListItemElement);
   }
 }
@@ -86,10 +87,7 @@ export const sharedListMethods = {
       this.dataForFilter = this.getItemData();
     }
   },
-  deselectSiblingItems(
-    this: CalcitePickList | CalciteValueList,
-    item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
-  ) {
+  deselectSiblingItems(this: CalcitePickList | CalciteValueList, item: pickOrValueListItem) {
     this.items.forEach((currentItem) => {
       if (currentItem !== item) {
         currentItem.toggleSelected(false);
@@ -99,10 +97,7 @@ export const sharedListMethods = {
       }
     });
   },
-  selectSiblings(
-    this: CalcitePickList | CalciteValueList,
-    item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement
-  ) {
+  selectSiblings(this: CalcitePickList | CalciteValueList, item: pickOrValueListItem) {
     if (!this.lastSelectedItem) {
       return;
     }
@@ -113,12 +108,10 @@ export const sharedListMethods = {
     const end = items.findIndex((currentItem) => {
       return currentItem.value === item.value;
     });
-    items
-      .slice(Math.min(start, end), Math.max(start, end))
-      .forEach((currentItem: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
-        currentItem.toggleSelected(true);
-        updateSelectedValuesMap(this.selectedValues, currentItem);
-      });
+    items.slice(Math.min(start, end), Math.max(start, end)).forEach((currentItem: pickOrValueListItem) => {
+      currentItem.toggleSelected(true);
+      updateSelectedValuesMap(this.selectedValues, currentItem);
+    });
   },
   handleFilter(this: CalcitePickList | CalciteValueList, event: CustomEvent): void {
     const filteredData = event.detail;
@@ -133,7 +126,7 @@ export const sharedListMethods = {
   },
   getItemData(this: CalcitePickList | CalciteValueList): Record<string, string | object>[] {
     const result: Record<string, string | object>[] = [];
-    this.items.forEach((item: HTMLCalcitePickListItemElement | HTMLCalciteValueListItemElement) => {
+    this.items.forEach((item: pickOrValueListItem) => {
       const obj: Record<string, string | object> = {};
       obj.label = item.textLabel || (item as HTMLCalcitePickListItemElement).textHeading;
       obj.description = item.textDescription;

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -72,8 +72,12 @@ export const sharedListMethods = {
       return;
     }
     const { items } = this;
-    const start = items.indexOf(this.lastSelectedItem);
-    const end = items.indexOf(item);
+    const start = items.findIndex((currentItem) => {
+      return currentItem.value === this.lastSelectedItem.value;
+    });
+    const end = items.findIndex((currentItem) => {
+      return currentItem.value === item.value;
+    });
     items.slice(Math.min(start, end), Math.max(start, end)).forEach((currentItem) => {
       currentItem.toggleSelected(true);
       this.selectedValues.set(currentItem.value, currentItem);

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -21,7 +21,11 @@ export const sharedListMethods = {
     this.setUpItems();
     this.setUpFilter();
   },
-  // LifeCycle functions
+  // --------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  // --------------------------------------------------------------------------
   initialize(this: CalcitePickList | CalciteValueList): void {
     this.setUpItems();
     this.setUpFilter();
@@ -32,7 +36,11 @@ export const sharedListMethods = {
   cleanUpObserver(this: CalcitePickList | CalciteValueList): void {
     this.observer.disconnect();
   },
-  // Listeners
+  // --------------------------------------------------------------------------
+  //
+  //  Listeners
+  //
+  // --------------------------------------------------------------------------
   calciteListItemChangeHandler(this: CalcitePickList | CalciteValueList, event: CustomEvent): void {
     const { selectedValues } = this;
     const { item, value, selected, shiftPressed } = event.detail;
@@ -50,7 +58,11 @@ export const sharedListMethods = {
     this.lastSelectedItem = item;
     this.calciteListChange.emit(selectedValues);
   },
-  // Private Methods
+  // --------------------------------------------------------------------------
+  //
+  //  Private Methods
+  //
+  // --------------------------------------------------------------------------
   setUpItems(
     this: CalcitePickList | CalciteValueList,
     tagname: "calcite-pick-list-item" | "calcite-pick-list-item"
@@ -132,4 +144,3 @@ export const sharedListMethods = {
     return result;
   }
 };
-export default sharedListMethods;

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -23,16 +23,13 @@ export const sharedListMethods = {
   },
   // LifeCycle functions
   initialize(this: CalcitePickList | CalciteValueList) {
-    // connectedCallback
     this.setUpItems();
     this.setUpFilter();
   },
   initializeObserver(this: CalcitePickList | CalciteValueList) {
-    // componentDidLoad
     this.observer.observe(this.el, { childList: true, subtree: true });
   },
   cleanUpObserver(this: CalcitePickList | CalciteValueList) {
-    // componentDidUnload
     this.observer.disconnect();
   },
   // Listeners

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -1,24 +1,27 @@
+import { CalcitePickList } from "./calcite-pick-list";
+import { CalciteValueList } from "../calcite-value-list/calcite-value-list";
+
 export const sharedListMethods = {
-  getObserver: new MutationObserver(() => {
+  mutationObserverCallback(this: CalcitePickList | CalciteValueList) {
     this.setUpItems();
     this.setUpFilter();
-  }),
+  },
   // LifeCycle functions
-  initialize() {
+  initialize(this: CalcitePickList | CalciteValueList) {
     // connectedCallback
     this.setUpItems();
     this.setUpFilter();
   },
-  initializeObserver() {
+  initializeObserver(this: CalcitePickList | CalciteValueList) {
     // componentDidLoad
     this.observer.observe(this.el, { childList: true, subtree: true });
   },
-  cleanUpObserver() {
+  cleanUpObserver(this: CalcitePickList | CalciteValueList) {
     // componentDidUnload
     this.observer.disconnect();
   },
   // Listeners
-  calciteListItemChangeHandler(event): void {
+  calciteListItemChangeHandler(this: CalcitePickList | CalciteValueList, event): void {
     const { selectedValues } = this;
     const { item, value, selected, shiftPressed } = event.detail;
     if (selected) {
@@ -37,7 +40,7 @@ export const sharedListMethods = {
     // this.calcitePickListSelectionChange.emit(selectedValues); picklist only
   },
   // Private Methods
-  setUpItems(tagname): void {
+  setUpItems(this: CalcitePickList | CalciteValueList, tagname): void {
     this.items = Array.from(this.el.querySelectorAll(tagname));
     this.items.forEach((item) => {
       const iconType = this.getIconType();
@@ -52,12 +55,12 @@ export const sharedListMethods = {
       }
     });
   },
-  setUpFilter(): void {
+  setUpFilter(this: CalcitePickList | CalciteValueList): void {
     if (this.filterEnabled) {
       this.dataForFilter = this.getItemData();
     }
   },
-  deselectSiblingItems(item: HTMLCalcitePickListItemElement) {
+  deselectSiblingItems(this: CalcitePickList | CalciteValueList, item: HTMLCalcitePickListItemElement) {
     this.items.forEach((currentItem) => {
       if (currentItem !== item) {
         currentItem.toggleSelected(false);
@@ -67,7 +70,10 @@ export const sharedListMethods = {
       }
     });
   },
-  selectSiblings(item: HTMLCalcitePickListItemElement) {
+  selectSiblings(
+    this: CalcitePickList | CalciteValueList,
+    item: HTMLCalcitePickListItemElement | HTMLCalcitePickListItemElement
+  ) {
     if (!this.lastSelectedItem) {
       return;
     }
@@ -83,7 +89,7 @@ export const sharedListMethods = {
       this.selectedValues.set(currentItem.value, currentItem);
     });
   },
-  handleFilter(event) {
+  handleFilter(this: CalcitePickList | CalciteValueList, event) {
     const filteredData = event.detail;
     const values = filteredData.map((item) => item.value);
     this.items.forEach((item) => {
@@ -94,7 +100,7 @@ export const sharedListMethods = {
       }
     });
   },
-  getItemData(): Record<string, string | object>[] {
+  getItemData(this: CalcitePickList | CalciteValueList): Record<string, string | object>[] {
     const result: Record<string, string | object>[] = [];
     this.items.forEach((item) => {
       const obj: Record<string, string | object> = {};

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -1,7 +1,7 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 
 export const tests = {
-  selectionAndDeselection(listType: "pick" | "list") {
+  selectionAndDeselection(listType: "pick" | "value") {
     describe("when multiple is false and a item is clicked", () => {
       it("should emit an event with the last selected item data", async () => {
         const page = await newE2EPage();
@@ -93,7 +93,7 @@ export const tests = {
       });
     });
   },
-  filterBehavior(listType: "pick" | "list") {
+  filterBehavior(listType: "pick" | "value") {
     let page: E2EPage = null;
     let item1: E2EElement;
     let item2: E2EElement;
@@ -204,7 +204,7 @@ export const tests = {
       expect(item2Visible).toBe(true);
     });
   },
-  disabledStateslistType(listType: "pick" | "list") {
+  disabledStates(listType: "pick" | "value") {
     it("disabled", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-${listType}-list disabled>
@@ -234,4 +234,3 @@ export const tests = {
     });
   }
 };
-export default tests;

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -1,0 +1,91 @@
+import { newE2EPage } from "@stencil/core/testing";
+
+export const tests = {
+  selectionAndDeselection(listType) {
+    describe("when multiple is false and a item is clicked", () => {
+      it("should emit an event with the last selected item data", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<calcite-${listType}-list>
+          <calcite-${listType}-list-item value="one" text-label="One"></calcite-${listType}-list-item>
+          <calcite-${listType}-list-item value="two" text-label="Two"></calcite-${listType}-list-item>
+        </calcite-${listType}-list>`);
+
+        const list = await page.find(`calcite-${listType}-list`);
+        const item1 = await list.find("[value=one]");
+        const item2 = await list.find("[value=two]");
+        const toggleSpy = await list.spyOnEvent("calciteListChange");
+
+        await item1.click();
+        await item2.click();
+        expect(toggleSpy).toHaveReceivedEventTimes(2);
+      });
+    });
+    describe("when multiple is true and a item is clicked", () => {
+      it("should emit an event with each selected item's data", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<calcite-${listType}-list multiple>
+          <calcite-${listType}-list-item value="one" text-label="One"></calcite-${listType}-list-item>
+          <calcite-${listType}-list-item value="two" text-label="Two"></calcite-${listType}-list-item>
+        </calcite-${listType}-list>`);
+
+        const list = await page.find(`calcite-${listType}-list`);
+        const item1 = await list.find("[value=one]");
+        const item2 = await list.find("[value=two]");
+        const toggleSpy = await list.spyOnEvent("calciteListChange");
+
+        await item1.click();
+        await item2.click();
+        await item2.click(); // deselect
+        expect(toggleSpy).toHaveReceivedEventTimes(3);
+      });
+    });
+    describe("preselected items", () => {
+      it("should be included in the list of selected items", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<calcite-${listType}-list multiple>
+          <calcite-${listType}-list-item value="one" text-label="One" selected></calcite-${listType}-list-item>
+          <calcite-${listType}-list-item value="two" text-label="Two"></calcite-${listType}-list-item>
+        </calcite-${listType}-list>`);
+
+        const numSelected = await page.evaluate((listType) => {
+          const list: HTMLCalcitePickListElement = document.querySelector(`calcite-${listType}-list`);
+          return list.getSelectedItems().then((result) => {
+            return result.size;
+          });
+        }, listType);
+
+        expect(numSelected).toBe(1);
+      });
+    });
+    describe("shift click behavior", () => {
+      it.only("should multi-select", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<calcite-${listType}-list multiple>
+          <calcite-${listType}-list-item value="one" text-label="One"></calcite-${listType}-list-item>
+          <calcite-${listType}-list-item value="two" text-label="Two"></calcite-${listType}-list-item>
+          <calcite-${listType}-list-item value="three" text-label="Three"></calcite-${listType}-list-item>
+        </calcite-${listType}-list>`);
+
+        const list = await page.find(`calcite-${listType}-list`);
+        const item1 = await list.find("[value=one]");
+        const item3 = await list.find("[value=three]");
+
+        await item1.click();
+        await page.keyboard.down("Shift");
+        await item3.click();
+        await page.keyboard.up("Shift");
+        await page.waitFor(5000);
+
+        const numSelected = await page.evaluate((listType) => {
+          const list: HTMLCalcitePickListElement = document.querySelector(`calcite-${listType}-list`);
+          return list.getSelectedItems().then((result) => {
+            return result.size;
+          });
+        }, listType);
+
+        expect(numSelected).toBe(3);
+      });
+    });
+  }
+};
+export default tests;

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -20,6 +20,7 @@ export const tests = {
         expect(toggleSpy).toHaveReceivedEventTimes(2);
       });
     });
+
     describe("when multiple is true and a item is clicked", () => {
       it("should emit an event with each selected item's data", async () => {
         const page = await newE2EPage();
@@ -39,6 +40,7 @@ export const tests = {
         expect(toggleSpy).toHaveReceivedEventTimes(3);
       });
     });
+
     describe("preselected items", () => {
       it("should be included in the list of selected items", async () => {
         const page = await newE2EPage();
@@ -59,6 +61,7 @@ export const tests = {
         expect(numSelected).toBe(1);
       });
     });
+
     describe("shift click behavior", () => {
       it("should multi-select", async () => {
         const page = await newE2EPage();
@@ -96,6 +99,7 @@ export const tests = {
     let item2: E2EElement;
     let item1Visible;
     let item2Visible;
+
     beforeEach(async () => {
       page = await newE2EPage();
       await page.setContent(`<calcite-${listType}-list filter-enabled="true">
@@ -115,6 +119,7 @@ export const tests = {
         (window as any).filterInput = filter.shadowRoot.querySelector("input");
       }, listType);
     });
+
     it("should match text in the text-label prop", async () => {
       // Match first item
       await page.evaluate(() => {
@@ -143,6 +148,7 @@ export const tests = {
       expect(item1Visible).toBe(false);
       expect(item2Visible).toBe(true);
     });
+
     it("should match text in the text-description prop", async () => {
       // Match first item
       await page.evaluate(() => {
@@ -171,6 +177,7 @@ export const tests = {
       expect(item1Visible).toBe(false);
       expect(item2Visible).toBe(true);
     });
+
     it("should match text in the metadata prop", async () => {
       await page.evaluate(() => {
         const filterInput = (window as any).filterInput;
@@ -211,6 +218,7 @@ export const tests = {
       await item1.click();
       expect(toggleSpy).toHaveReceivedEventTimes(0);
     });
+
     it("loading", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-${listType}-list loading>

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -1,7 +1,7 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 
 export const tests = {
-  selectionAndDeselection(listType) {
+  selectionAndDeselection(listType: "pick" | "list") {
     describe("when multiple is false and a item is clicked", () => {
       it("should emit an event with the last selected item data", async () => {
         const page = await newE2EPage();
@@ -90,7 +90,7 @@ export const tests = {
       });
     });
   },
-  filterBehavior(listType) {
+  filterBehavior(listType: "pick" | "list") {
     let page: E2EPage = null;
     let item1: E2EElement;
     let item2: E2EElement;
@@ -197,7 +197,7 @@ export const tests = {
       expect(item2Visible).toBe(true);
     });
   },
-  disabledStates(listType) {
+  disabledStateslistType(listType: "pick" | "list") {
     it("disabled", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-${listType}-list disabled>

--- a/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.e2e.ts
@@ -160,7 +160,7 @@ describe("calcite-tip-manager", () => {
       await page.evaluate((newTipId) => {
         const mgr = document.querySelector("calcite-tip-manager");
         const newTip = mgr.querySelector("calcite-tip:last-child").cloneNode(true);
-        newTip.id = newTipId;
+        (newTip as HTMLElement).id = newTipId;
         mgr.appendChild(newTip);
       }, newTipId);
       await page.waitForChanges();

--- a/src/components/calcite-tip-manager/calcite-tip-manager.spec.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.spec.ts
@@ -1,8 +1,8 @@
+// TODO: Uncomment this test when there's a resolution to this bug. https://github.com/ionic-team/stencil/issues/1669
 // import { CalciteTipManager } from "./calcite-tip-manager";
 
 describe.skip("CalciteTipManager", () => {
   it("should increment/decrement the selectedIndex when the public next/prev methods are called", () => {
-    // TODO: Uncomment this test when there's a resolution to this bug. https://github.com/ionic-team/stencil/issues/1669
     // const tipManager = new CalciteTipManager();
     // tipManager.total = 2; //needed to
     // expect(tipManager.selectedIndex).toBe(0);

--- a/src/components/calcite-tip-manager/calcite-tip-manager.spec.ts
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.spec.ts
@@ -1,4 +1,4 @@
-import { CalciteTipManager } from "./calcite-tip-manager";
+// import { CalciteTipManager } from "./calcite-tip-manager";
 
 describe.skip("CalciteTipManager", () => {
   it("should increment/decrement the selectedIndex when the public next/prev methods are called", () => {

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -14,6 +14,11 @@ export class CalciteValueListItem {
   // --------------------------------------------------------------------------
 
   /**
+   * Compact reduces the size of the item.
+   */
+  @Prop({ reflect: true }) compact = false;
+
+  /**
    * When true, the item cannot be clicked and is visually muted
    */
   @Prop({ reflect: true }) disabled = false;
@@ -86,6 +91,7 @@ export class CalciteValueListItem {
     return (
       <Host>
         <calcite-pick-list-item
+          compact={this.compact}
           ref={this.getPickListRef}
           disabled={this.disabled}
           selected={this.selected}

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -1,49 +1,14 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { ICON_TYPES } from "./resources";
 import { hidden, renders } from "../../tests/commonTests";
+import tests from "../calcite-pick-list/shared-list-tests";
 
 describe("calcite-value-list", () => {
   it("renders", async () => renders("calcite-value-list"));
   it("honors hidden attribute", async () => hidden("calcite-value-list"));
 
-  describe("Selection and Deselection", () => {
-    describe("when multiple is false and a item is clicked", () => {
-      it("should emit an event with the last selected item data", async () => {
-        const page = await newE2EPage();
-        await page.setContent(`<calcite-value-list>
-          <calcite-value-list-item value="one" text-label="test"></calcite-value-list-item>
-          <calcite-value-list-item value="two" text-label="test"></calcite-value-list-item>
-        </calcite-value-list>`);
-
-        const valueList = await page.find("calcite-value-list");
-        const item1 = await valueList.find("[value=one]");
-        const item2 = await valueList.find("[value=two]");
-        const toggleSpy = await valueList.spyOnEvent("calciteListChange");
-
-        await item1.click();
-        await item2.click();
-        expect(toggleSpy).toHaveReceivedEventTimes(2);
-      });
-    });
-    describe("when multiple is true and a item is clicked", () => {
-      it("should emit an event with each selected item's data", async () => {
-        const page = await newE2EPage();
-        await page.setContent(`<calcite-value-list multiple>
-          <calcite-value-list-item value="one" text-label="test"></calcite-value-list-item>
-          <calcite-value-list-item value="two" text-label="test"></calcite-value-list-item>
-        </calcite-value-list>`);
-
-        const valueList = await page.find("calcite-value-list");
-        const item1 = await valueList.find("[value=one]");
-        const item2 = await valueList.find("[value=two]");
-        const toggleSpy = await valueList.spyOnEvent("calciteListChange");
-
-        await item1.click();
-        await item2.click();
-        await item2.click(); // deselect
-        expect(toggleSpy).toHaveReceivedEventTimes(3);
-      });
-    });
+  describe.only("Selection and Deselection", () => {
+    tests.selectionAndDeselection("value");
   });
 
   describe("icon logic", () => {

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -1,14 +1,16 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { ICON_TYPES } from "./resources";
 import { hidden, renders } from "../../tests/commonTests";
-import tests from "../calcite-pick-list/shared-list-tests";
+import { tests } from "../calcite-pick-list/shared-list-tests";
+
+const { selectionAndDeselection, filterBehavior, disabledStates } = tests;
 
 describe("calcite-value-list", () => {
   it("renders", async () => renders("calcite-value-list"));
   it("honors hidden attribute", async () => hidden("calcite-value-list"));
 
   describe("Selection and Deselection", () => {
-    tests.selectionAndDeselection("value");
+    selectionAndDeselection("value");
   });
 
   describe("icon logic", () => {
@@ -35,10 +37,10 @@ describe("calcite-value-list", () => {
   });
 
   describe("filter behavior (hide/show items)", () => {
-    tests.filterBehavior("value");
+    filterBehavior("value");
   });
 
   describe("disabled states", () => {
-    tests.disabledStates("value");
+    disabledStates("value");
   });
 });

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { CSS, ICON_TYPES } from "./resources";
+import { ICON_TYPES } from "./resources";
 import { hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-value-list", () => {

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -7,7 +7,7 @@ describe("calcite-value-list", () => {
   it("renders", async () => renders("calcite-value-list"));
   it("honors hidden attribute", async () => hidden("calcite-value-list"));
 
-  describe.only("Selection and Deselection", () => {
+  describe("Selection and Deselection", () => {
     tests.selectionAndDeselection("value");
   });
 
@@ -32,5 +32,13 @@ describe("calcite-value-list", () => {
       const icon = await item.getProperty("icon");
       expect(icon).toBeNull();
     });
+  });
+
+  describe("filter behavior (hide/show items)", () => {
+    tests.filterBehavior("value");
+  });
+
+  describe("disabled states", () => {
+    tests.disabledStates("value");
   });
 });

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -219,10 +219,10 @@ export class CalciteValueList {
   }
 
   render() {
-    const { dataForFilter, handleFilter, filterEnabled, loading } = this;
+    const { dataForFilter, handleFilter, filterEnabled, loading, disabled } = this;
     return (
-      <Host>
-        <div class={CSS.container} aria-busy={loading}>
+      <Host aria-disabled={disabled} aria-busy={loading}>
+        <div class={CSS.container}>
           <header>
             {filterEnabled ? (
               <calcite-filter

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -13,9 +13,22 @@ import {
 } from "@stencil/core";
 import guid from "../utils/guid";
 import { CSS, ICON_TYPES, TEXT } from "./resources";
-import sharedListMethods from "../calcite-pick-list/shared-list-logic";
+import { sharedListMethods } from "../calcite-pick-list/shared-list-logic";
 import { VNode } from "@stencil/core/dist/declarations";
 import CalciteScrim from "../utils/CalciteScrim";
+
+const {
+  mutationObserverCallback,
+  initialize,
+  initializeObserver,
+  cleanUpObserver,
+  calciteListItemChangeHandler,
+  setUpItems,
+  deselectSiblingItems,
+  selectSiblings,
+  handleFilter,
+  getItemData
+} = sharedListMethods;
 
 /**
  * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
@@ -81,7 +94,7 @@ export class CalciteValueList {
 
   guid = `calcite-value-list-${guid()}`;
 
-  observer = new MutationObserver(sharedListMethods.mutationObserverCallback.bind(this));
+  observer = new MutationObserver(mutationObserverCallback.bind(this));
 
   sortables: Sortable[] = [];
 
@@ -99,16 +112,16 @@ export class CalciteValueList {
   //
   // --------------------------------------------------------------------------
   connectedCallback() {
-    sharedListMethods.initialize.call(this);
+    initialize.call(this);
   }
 
   componentDidLoad() {
     this.setUpDragAndDrop();
-    sharedListMethods.initializeObserver.call(this);
+    initializeObserver.call(this);
   }
 
   componentDidUnload() {
-    sharedListMethods.cleanUpObserver.call(this);
+    cleanUpObserver.call(this);
     this.cleanUpDragAndDrop();
   }
 
@@ -131,7 +144,7 @@ export class CalciteValueList {
   @Event() calciteListOrderChange: EventEmitter;
 
   @Listen("calciteListItemChange") calciteListItemChangeHandler(event) {
-    sharedListMethods.calciteListItemChangeHandler.call(this, event);
+    calciteListItemChangeHandler.call(this, event);
   }
 
   @Listen("calciteListItemPropsUpdated") calciteListItemPropsUpdatedHandler() {
@@ -145,7 +158,7 @@ export class CalciteValueList {
   // --------------------------------------------------------------------------
 
   setUpItems(): void {
-    sharedListMethods.setUpItems.call(this, "calcite-value-list-item");
+    setUpItems.call(this, "calcite-value-list-item");
   }
 
   setUpFilter(): void {
@@ -182,13 +195,13 @@ export class CalciteValueList {
     this.sortables = [];
   }
 
-  deselectSiblingItems = sharedListMethods.deselectSiblingItems.bind(this);
+  deselectSiblingItems = deselectSiblingItems.bind(this);
 
-  selectSiblings = sharedListMethods.selectSiblings.bind(this);
+  selectSiblings = selectSiblings.bind(this);
 
-  handleFilter = sharedListMethods.handleFilter.bind(this);
+  handleFilter = handleFilter.bind(this);
 
-  getItemData = sharedListMethods.getItemData.bind(this);
+  getItemData = getItemData.bind(this);
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -33,6 +33,11 @@ export class CalciteValueList {
   // --------------------------------------------------------------------------
 
   /**
+   * Compact reduces the size of all items in the list.
+   */
+  @Prop({ reflect: true }) compact = false;
+
+  /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
    */
   @Prop({ reflect: true }) disabled = false;

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -194,7 +194,7 @@ export class CalciteValueList {
   //
   // --------------------------------------------------------------------------
 
-  @Method() async getSelectedItems(): Promise<object> {
+  @Method() async getSelectedItems(): Promise<Map<string, object>> {
     return this.selectedValues;
   }
 

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -81,10 +81,7 @@ export class CalciteValueList {
 
   guid = `calcite-value-list-${guid()}`;
 
-  observer = new MutationObserver(() => {
-    this.setUpItems();
-    this.setUpFilter();
-  });
+  observer = new MutationObserver(sharedListMethods.mutationObserverCallback.bind(this));
 
   sortables: Sortable[] = [];
 


### PR DESCRIPTION
**Related Issue:** #461, #400  

## Summary

TL;DR; I've abstracted some shared code for PickList and ValueList.
In working on a couple bugs for the lists, I've realized that they are already starting to diverge in undesirable ways. From the get-go the test suite was more extensive on pick-list than value-list. And there was quite a bit of duplicated code. I left them isolated since it seemed like these might diverge more based on information from @asangma and @kat10140 but so far they are still very similar.

## Changes

* Several methods have been abstracted to a new filed called `share-list-logic.ts` and both components are importing that as a dependency and use those functions for several internal methods.
* Several tests have been abstracted into `shared-list-tests.ts`, mainly the selection/deselection tests as well as the filtering logic.

## Future
I think it might be possible to also share render logic, but that would need to be abstracted into a functionalComponent at minimum. It might also be possible using higher-order component patterns to share more of the class configuration (props, states and other decorators). Going to pause on that rabbit hole for now so I can get these other bug fixes shipped first.

**_NOTE:_** This is being merged into one of my bug fix branches because I wrote the new filter tests for that bug, then decided to do this rather than copy all of those tests over.