### PR TITLE
Added z-index for disabled and loading panel.

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -18,6 +18,12 @@
   display: none;
 }
 
+:host([loading]) .container,
+:host([disabled]) .container {
+  position: relative;
+  z-index: 1;
+}
+
 .header {
   align-items: center;
   display: flex;


### PR DESCRIPTION
**Related Issue:**  (#472)

## Summary
Panel. z-index for loading and disabled
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
