### PR TITLE
fix: calcite-action loading & calcite-flow-item footer in Edge browser

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -51,6 +51,10 @@
   }
 }
 
+.slot-container--hidden {
+  display: none;
+}
+
 .button--text-visible {
   width: 100%;
 }

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -90,10 +90,9 @@ export class CalciteAction {
 
     const slotContainerNode = (
       <div
-        class={{
-          [CSS.slotContainer]: true,
+        class={classnames(CSS.slotContainer, {
           [CSS.slotContainerHidden]: loading
-        }}
+        })}
       >
         <slot />
       </div>

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -88,9 +88,23 @@ export class CalciteAction {
   render() {
     const { compact, disabled, loading, el, textEnabled, textDisplay, label, text } = this;
 
+    const slotContainerNode = (
+      <div
+        class={{
+          [CSS.slotContainer]: true,
+          [CSS.slotContainerHidden]: loading
+        }}
+      >
+        <slot />
+      </div>
+    );
+
+    const calciteLoaderNode = loading ? <calcite-loader is-active inline></calcite-loader> : null;
+
     const iconContainerNode = (
       <div key="icon-container" aria-hidden="true" class={CSS.iconContainer}>
-        {!loading ? <slot /> : <calcite-loader is-active inline></calcite-loader>}
+        {slotContainerNode}
+        {calciteLoaderNode}
       </div>
     );
 

--- a/src/components/calcite-action/resources.ts
+++ b/src/components/calcite-action/resources.ts
@@ -4,5 +4,7 @@ export const CSS = {
   buttonTextInteractive: "button--text-interactive",
   buttonCompact: "button--compact",
   iconContainer: "icon-container",
+  slotContainer: "slot-container",
+  slotContainerHidden: "slot-container--hidden",
   textContainer: "text-container"
 };

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -163,7 +163,7 @@ export class CalciteFlowItem {
 
     return hasFooterActions ? (
       <div slot="footer">
-        <slot name="footer-actions" />{" "}
+        <slot name="footer-actions" />
       </div>
     ) : null;
   }

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -161,7 +161,11 @@ export class CalciteFlowItem {
   renderFooterActions() {
     const hasFooterActions = !!this.el.querySelector("[slot=footer-actions]");
 
-    return hasFooterActions ? <slot slot="footer" name="footer-actions" /> : null;
+    return hasFooterActions ? (
+      <div slot="footer">
+        <slot name="footer-actions" />{" "}
+      </div>
+    ) : null;
   }
 
   renderSingleActionContainer() {


### PR DESCRIPTION
**Related Issue:** None

## Summary

- Fixes loading spinner to show without the SVG in the CalciteAction in Edge.
  - The loading spinner was displaying above the SVG icon. This hides the svg when loading.
- Fixes footer display issue in CalciteFlowItem in Edge.
  - A slot with another slot attribute won't work correctly in the Edge Polyfill