### PR TITLE
fix: flow-item and panel footer buttons

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -48,7 +48,7 @@ calcite-panel {
   display: block;
 }
 
-slot[name="footer-actions"]::slotted(div) {
+.footer-actions {
   display: flex;
-  padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
+  width: 100%;
 }

--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -47,3 +47,8 @@ calcite-panel {
 .menu--open {
   display: block;
 }
+
+slot[name="footer-actions"]::slotted(div) {
+  display: flex;
+  padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
+}

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -162,10 +162,8 @@ export class CalciteFlowItem {
     const hasFooterActions = !!this.el.querySelector("[slot=footer-actions]");
 
     return hasFooterActions ? (
-      <div slot="footer">
-        <div class={CSS.footerActions}>
-          <slot name="footer-actions" slot="footer" />
-        </div>
+      <div slot="footer" class={CSS.footerActions}>
+        <slot name="footer-actions" />
       </div>
     ) : null;
   }

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -163,7 +163,9 @@ export class CalciteFlowItem {
 
     return hasFooterActions ? (
       <div slot="footer">
-        <slot name="footer-actions" />
+        <div class={CSS.footerActions}>
+          <slot name="footer-actions" slot="footer" />
+        </div>
       </div>
     ) : null;
   }

--- a/src/components/calcite-flow-item/resources.ts
+++ b/src/components/calcite-flow-item/resources.ts
@@ -1,6 +1,7 @@
 export const CSS = {
   heading: "heading",
   backButton: "back-button",
+  footerActions: "footer-actions",
   singleActionContainer: "single-action-container",
   menuContainer: "menu-container",
   menuButton: "menu-button",

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -54,10 +54,6 @@ slot[name="header-content"]::slotted(.heading) {
 }
 
 .footer {
-  align-items: center;
+  width: 100%;
   border-top: 1px solid var(--calcite-app-border);
-  display: flex;
-  justify-content: space-around;
-  padding: var(--calcite-app-cap-spacing) var(--calcite-app-side-spacing-half);
-  flex-flow: row nowrap;
 }

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -57,3 +57,8 @@ slot[name="header-content"]::slotted(.heading) {
   width: 100%;
   border-top: 1px solid var(--calcite-app-border);
 }
+
+slot[name="footer"]::slotted(div) {
+  display: flex;
+  justify-content: space-evenly;
+}

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -54,11 +54,9 @@ slot[name="header-content"]::slotted(.heading) {
 }
 
 .footer {
-  width: 100%;
   border-top: 1px solid var(--calcite-app-border);
-}
-
-slot[name="footer"]::slotted(div) {
   display: flex;
   justify-content: space-evenly;
+  padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
+  width: calc(100% - #{var(--calcite-app-side-spacing)});
 }

--- a/src/demos/calcite-shell-full-window.html
+++ b/src/demos/calcite-shell-full-window.html
@@ -446,10 +446,8 @@
                   </calcite-block-section>
                 </calcite-block-content>
               </calcite-block>
-              <div slot="footer-actions">
-                <calcite-button width="half">Save</calcite-button>
-                <calcite-button width="half" appearance="clear">Cancel</button>
-              </div>
+              <calcite-button slot="footer-actions" width="half">Save</calcite-button>
+              <calcite-button slot="footer-actions" width="half" appearance="clear">Cancel</button>
             </calcite-flow-item>
           </calcite-flow>
         </calcite-shell-panel>
@@ -477,6 +475,7 @@
           <calcite-pick-list-item text-label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
           <calcite-pick-list-item text-label="YEAH!" value="5"></calcite-pick-list-item>
         </calcite-pick-list>
+        <calcite-button slot="footer" width="half" appearance="clear">Yeah dude!</calcite-button>
       </calcite-panel>
     </calcite-popover>
     <script>

--- a/src/demos/calcite-shell-full-window.html
+++ b/src/demos/calcite-shell-full-window.html
@@ -447,8 +447,8 @@
                 </calcite-block-content>
               </calcite-block>
               <div slot="footer-actions">
-                <button>Save</button>
-                <button>Cancel</button>
+                <calcite-button width="half">Save</calcite-button>
+                <calcite-button width="half" appearance="clear">Cancel</button>
               </div>
             </calcite-flow-item>
           </calcite-flow>


### PR DESCRIPTION
**Related Issue:** #367 

## Summary
Fixes layout of calcite-button (or other generic button) in panel footer. flow-item inherits the fix with a bit of additional styling.

Also updated full-window demo to use calcite-button.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
