### PR TITLE
test(block): add tests for loading and disabled properties

### DIFF
--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -1,6 +1,8 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EElement, newE2EPage } from "@stencil/core/testing";
 import { CSS, SLOTS, TEXT } from "./resources";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { setUpPage } from "../../tests/utils";
+import { CalciteBlock } from "./calcite-block";
 
 describe("calcite-block", () => {
   it("renders", async () => renders("calcite-block"));
@@ -27,6 +29,56 @@ describe("calcite-block", () => {
         <label slot=${SLOTS.control}>test <input placeholder="control"/></label>
       </calcite-block>
   `));
+
+  it("it can be disabled", async () => {
+    const page = await setUpPage(
+      `
+        <calcite-block heading="heading" summary="summary" open collapsible>
+          <div class="content">content</div>
+        </calcite-block>
+    `,
+      { withPeerDependencies: true }
+    );
+
+    const content = await page.find(".content");
+    const clickSpy = await content.spyOnEvent("click");
+    await content.click();
+    expect(clickSpy).toHaveReceivedEventTimes(1);
+
+    const block = await page.find("calcite-block");
+    block.setProperty("disabled", true);
+    await page.waitForChanges();
+
+    await content.click();
+    expect(clickSpy).toHaveReceivedEventTimes(1);
+  });
+
+  it("has a loading state", async () => {
+    const page = await setUpPage(
+      `
+        <calcite-block heading="heading" summary="summary" open collapsible>
+          <div class="content">content</div>
+        </calcite-block>
+    `,
+      { withPeerDependencies: true }
+    );
+
+    expect(await page.find("calcite-block >>> calcite-loader")).toBeNull();
+
+    const content = await page.find(".content");
+    const clickSpy = await content.spyOnEvent("click");
+    await content.click();
+    expect(clickSpy).toHaveReceivedEventTimes(1);
+
+    const block = await page.find("calcite-block");
+    block.setProperty("loading", true);
+    await page.waitForChanges();
+
+    await content.click();
+    expect(clickSpy).toHaveReceivedEventTimes(1);
+
+    expect(await page.find("calcite-block >>> calcite-loader")).toBeTruthy();
+  });
 
   it("can display/hide content", async () => {
     const page = await newE2EPage();

--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -1,8 +1,7 @@
-import { E2EElement, newE2EPage } from "@stencil/core/testing";
+import { newE2EPage } from "@stencil/core/testing";
 import { CSS, SLOTS, TEXT } from "./resources";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 import { setUpPage } from "../../tests/utils";
-import { CalciteBlock } from "./calcite-block";
 
 describe("calcite-block", () => {
   it("renders", async () => renders("calcite-block"));

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -154,6 +154,18 @@
           <div>Some content</div>
         </calcite-block>
 
+        <h2>Disabled</h2>
+
+        <calcite-block disabled heading="this block is disabled" collapsible open>
+          <div>Some content</div>
+        </calcite-block>
+
+        <h2>Loading</h2>
+
+        <calcite-block loading heading="this block is loading" collapsible open>
+          <div>Some content</div>
+        </calcite-block>
+
         <h2>RTL</h2>
 
         <calcite-block dir="rtl" heading="Heading" summary="summary" open collapsible>

--- a/src/demos/calcite-block.html
+++ b/src/demos/calcite-block.html
@@ -154,18 +154,6 @@
           <div>Some content</div>
         </calcite-block>
 
-        <h2>Disabled</h2>
-
-        <calcite-block disabled heading="this block is disabled" collapsible open>
-          <div>Some content</div>
-        </calcite-block>
-
-        <h2>Loading</h2>
-
-        <calcite-block loading heading="this block is loading" collapsible open>
-          <div>Some content</div>
-        </calcite-block>
-
         <h2>RTL</h2>
 
         <calcite-block dir="rtl" heading="Heading" summary="summary" open collapsible>


### PR DESCRIPTION
**Related Issue:** #402

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Adds missing Block tests.

**Note**: Left similarities between tests as is. Extracting into a helper didn't make things clearer. Open to suggestions though. 😄 