### PR TITLE
style(action-pad): added missed styles

### DIFF
--- a/src/components/calcite-action-pad/calcite-action-pad.scss
+++ b/src/components/calcite-action-pad/calcite-action-pad.scss
@@ -5,13 +5,14 @@
 .container {
   display: flex;
   flex-direction: column;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
-  padding: var(--calcite-app-cap-spacing-eighth) var(--calcite-app-side-spacing-quarter);
+  box-shadow: var(--calcite-app-shadow-2);
   animation: calcite-app-fade-in var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function);
 }
 
 ::slotted(calcite-action-group) {
   border-bottom: 1px solid var(--calcite-app-border);
+  padding-bottom: 0;
+  padding-top: 0;
 }
 
 ::slotted(calcite-action-group:last-child) {


### PR DESCRIPTION
**Related Issue:** #506

## Summary
Added missing styles to align with calcite-components.

cc @russroberts 

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
