### PR TITLE
style(block-section): missed style for switch mode

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -11,7 +11,7 @@
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
+  padding: var(--calcite-app-cap-spacing-half) 0;
   user-select: none;
   calcite-switch {
     margin: 0;


### PR DESCRIPTION
**Related Issue:** #507

## Summary
Removed redundant padding.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
cc @AdelheidF 