### PR TITLE
style(block-section): label spacing in switch mode

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.scss
+++ b/src/components/calcite-block-section/calcite-block-section.scss
@@ -14,6 +14,11 @@
   padding: var(--calcite-app-cap-spacing-half) 0;
   user-select: none;
   calcite-switch {
-    margin: 0;
+    margin: var(--calcite-app-cap-spacing-third) 0 0 var(--calcite-app-side-spacing-half);
   }
+}
+
+.calcite--rtl .toggle--switch calcite-switch {
+  margin-left: 0;
+  margin-right: var(--calcite-app-side-spacing-half);
 }

--- a/src/demos/calcite-shell-full-window.html
+++ b/src/demos/calcite-shell-full-window.html
@@ -154,11 +154,14 @@
                 </calcite-action>
               </calcite-block-content>
             </calcite-block>
-            <calcite-block collapsible open heading="Another Block" summary="This is the primary.">
+            <calcite-block collapsible open heading="Transpancy by predominant percentage">
               <calcite-block-content>
-                <div style="height: 300px;">
-                  <p>Cool thing.</p>
-                </div>
+                <calcite-block-section text="Set transparency based on the predominant percentage" toggle-display="switch" open>
+                  <label style="display: flex;flex-flow: column; margin: 15px 0;">
+                    Cool
+                    <input type="text" style="padding: 0.5rem;"/>
+                  </label>
+                </calcite-block-section>
               </calcite-block-content>
             </calcite-block>
             <calcite-block collapsible open heading="Additional Block" summary="This is the primary.">
@@ -465,7 +468,7 @@
     <calcite-popover placement="right-start" reference-element="action-pad-button" add-click-handle class="popover">
       <calcite-panel theme="light">
         <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
-        <calcite-pick-list filter-enabled>
+        <calcite-pick-list filter-enabled filter-sticky>
           <calcite-action slot="menu-actions" label="options">
               <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" fill="currentColor" viewBox="0 0 16 16"><path d="M14 9.05A1.05 1.05 0 1 1 15.05 8 1.05 1.05 0 0 1 14 9.05zm-6 0A1.05 1.05 0 1 1 9.05 8 1.05 1.05 0 0 1 8 9.05zm-6 0A1.05 1.05 0 1 1 3.05 8 1.05 1.05 0 0 1 2 9.05z"></path></svg>
           </calcite-action>
@@ -473,9 +476,9 @@
           <calcite-pick-list-item text-label="about the NASA shuttle falling in the sea" value="2"></calcite-pick-list-item>
           <calcite-pick-list-item text-label="about starvation and the food that Live Aid bought" value="3"></calcite-pick-list-item>
           <calcite-pick-list-item text-label="about disease, baby rock, Hudson, rock," value="4"></calcite-pick-list-item>
-          <calcite-pick-list-item text-label="YEAH!" value="5"></calcite-pick-list-item>
         </calcite-pick-list>
-        <calcite-button slot="footer" width="half" appearance="clear">Yeah dude!</calcite-button>
+        <calcite-button slot="footer" width="half" >Yeah!</calcite-button>
+        <calcite-button slot="footer" width="half" appearance="clear">Naw.</calcite-button>
       </calcite-panel>
     </calcite-popover>
     <script>


### PR DESCRIPTION
**Related Issue:** #455

## Summary
Added some spacing and RTL spacing for when block-section is in switch mode and the label is long.

Includes some updates to full-window demo.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
