### PR TITLE
refactor: use CSS vars for calculations

### DIFF
--- a/src/assets/styles/_layout.scss
+++ b/src/assets/styles/_layout.scss
@@ -6,28 +6,28 @@ $animation-time: 250ms !default;
   --calcite-app-side-spacing: #{$side-spacing};
   --calcite-app-cap-spacing: #{$cap-spacing};
 
-  --calcite-app-side-spacing-three-quarters: #{floor($side-spacing * 3/4)};
-  --calcite-app-cap-spacing-three-quarters: #{floor($cap-spacing * 3/4)};
+  --calcite-app-side-spacing-three-quarters: calc(var(--calcite-app-side-spacing) * 3 / 4);
+  --calcite-app-cap-spacing-three-quarters: calc(var(--calcite-app-cap-spacing) * 3 / 4);
 
-  --calcite-app-side-spacing-half: #{floor($side-spacing / 2)};
-  --calcite-app-cap-spacing-half: #{floor($cap-spacing / 2)};
+  --calcite-app-side-spacing-half: calc(var(--calcite-app-side-spacing) / 2);
+  --calcite-app-cap-spacing-half: calc(var(--calcite-app-cap-spacing) / 2);
 
-  --calcite-app-side-spacing-third: #{floor($side-spacing / 3)};
-  --calcite-app-cap-spacing-third: #{floor($cap-spacing / 3)};
+  --calcite-app-side-spacing-third: calc(var(--calcite-app-side-spacing) / 3);
+  --calcite-app-cap-spacing-third: calc(var(--calcite-app-cap-spacing) / 3);
 
-  --calcite-app-side-spacing-quarter: #{floor($side-spacing / 4)};
-  --calcite-app-cap-spacing-quarter: #{floor($cap-spacing / 4)};
+  --calcite-app-side-spacing-quarter: calc(var(--calcite-app-side-spacing) / 4);
+  --calcite-app-cap-spacing-quarter: calc(var(--calcite-app-cap-spacing) / 4);
 
-  --calcite-app-side-spacing-eighth: #{ceil($side-spacing / 8)};
-  --calcite-app-cap-spacing-eighth: #{ceil($cap-spacing / 8)};
+  --calcite-app-side-spacing-eighth: calc(var(--calcite-app-side-spacing) / 8);
+  --calcite-app-cap-spacing-eighth: calc(var(--calcite-app-cap-spacing) / 8);
 
   --calcite-app-cap-spacing-minimum: 1px;
 
-  --calcite-app-side-spacing-plus-half: #{floor($side-spacing * 1.5)};
-  --calcite-app-cap-spacing-plus-half: #{floor($cap-spacing * 1.5)};
+  --calcite-app-side-spacing-plus-half: calc(var(--calcite-app-side-spacing) * 1.5);
+  --calcite-app-cap-spacing-plus-half: calc(var(--calcite-app-cap-spacing) * 1.5);
 
-  --calcite-app-side-spacing-double: #{floor($side-spacing * 2)};
-  --calcite-app-cap-spacing-double: #{floor($cap-spacing * 2)};
+  --calcite-app-side-spacing-double: calc(var(--calcite-app-side-spacing) * 2);
+  --calcite-app-cap-spacing-double: calc(var(--calcite-app-cap-spacing) * 2);
 
   --calcite-app-menu-min-width: 10rem;
   --calcite-app-menu-offset: 0px;


### PR DESCRIPTION
**Related Issue:** #516

## Summary
Use CSS vars instead of Sass for calculating fractional values for sizes.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Note, this allow an app to do this and have it work for all calculated values.
```
:root {
        --calcite-app-side-spacing: 24px;
        --calcite-app-cap-spacing: 24px;
      }
```