### PR TITLE
add default focus style for calcite-action

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -31,6 +31,10 @@
     color: var(--calcite-app-foreground-hover);
     fill: var(--calcite-app-foreground-hover);
   }
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 3px $blue;
+  }
   .icon-container {
     max-width: var(--calcite-app-icon-size);
     max-height: var(--calcite-app-icon-size);


### PR DESCRIPTION
**Related Issue:** #335 

## Summary

Added a focus style to `calcite-action >>> button`.

@asangma please review the color and thickness.
