### PR TITLE
remove Edge's nonStandard broken clear btn

### DIFF
--- a/src/components/calcite-filter/calcite-filter.scss
+++ b/src/components/calcite-filter/calcite-filter.scss
@@ -24,6 +24,9 @@ input[type="text"] {
   transition: padding var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function),
     box-shadow var(--calcite-app-animation-time-fast) var(--calcite-app-easing-function);
   width: 100%;
+  &::-ms-clear {
+    display: none;
+  }
 }
 
 .search-icon {


### PR DESCRIPTION
**Related Issue:** #340 

## Summary

Removing the Edge specific clear button.
Reasoning: https://github.com/Esri/calcite-app-components/issues/340#issuecomment-551280340