### PR TITLE
style(calcite-value-list-item) Remove box-shadow border from last child.

### DIFF
--- a/src/components/calcite-value-list-item/calcite-value-list-item.scss
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.scss
@@ -11,6 +11,7 @@ calcite-pick-list-item {
 }
 
 :host(:last-child) calcite-pick-list-item {
+  box-shadow: none;
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
**Related Issue:** #517

## Summary
Remove box-shadow (border) from last child.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
