### PR TITLE
fix(value-list-item): last child selection

### DIFF
--- a/src/components/calcite-value-list-item/calcite-value-list-item.scss
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.scss
@@ -15,7 +15,8 @@ calcite-pick-list-item {
   margin-bottom: 0;
 }
 
-calcite-pick-list-item[selected] {
+calcite-pick-list-item[selected],
+:host(:last-child) calcite-pick-list-item[selected] {
   z-index: 1;
   @include borderShadowActive();
 }


### PR DESCRIPTION
**Related Issue:**  (#542)

## Summary
Last value-list-item was not getting a selected state.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
