### PR TITLE
fix(panel): header-content layout when leading slot is empty

### DIFF
--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -19,7 +19,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: var(--calcite-app-header-min-height);
+  flex-basis: var(--calcite-app-header-min-height);
   color: var(--calcite-app-foreground);
   fill: var(--calcite-app-foreground);
 }

--- a/src/assets/styles/_layout.scss
+++ b/src/assets/styles/_layout.scss
@@ -35,7 +35,7 @@ $cap-spacing: 16px !default;
 
   --calcite-app-border-radius: 3px;
 
-  --calcite-app-header-min-height: 3rem;
+  --calcite-app-header-min-height: calc(var(--calcite-app-cap-spacing) * 3);
 
   // shadows
   --calcite-app-shadow-0: 0 2px 4px rgba(0, 0, 0, 0.1);

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -53,7 +53,11 @@
 
 .header-content {
   overflow: hidden;
-  padding: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-half);
+  padding: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing);
+}
+
+.header-leading-content + .header-content {
+  padding-left: var(--calcite-app-side-spacing-quarter);
 }
 
 slot[name="header-content"]::slotted(.heading) {
@@ -81,7 +85,12 @@ slot[name="header-content"]::slotted(.heading) {
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
 }
 
-.calcite--rtl .header-trailing-content {
-  margin-left: unset;
-  margin-right: auto;
+.calcite--rtl {
+  .header-leading-content + .header-content {
+    padding-right: var(--calcite-app-side-spacing-quarter);
+  }
+  .header-trailing-content {
+    margin-left: 0;
+    margin-right: auto;
+  }
 }

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -87,7 +87,7 @@ slot[name="header-content"]::slotted(.heading) {
 
 .calcite--rtl {
   .header-leading-content + .header-content {
-    padding-right: var(--calcite-app-side-spacing-quarter);
+    padding-right: var(--calcite-app-side-spacing-half);
   }
   .header-trailing-content {
     margin-left: 0;

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -57,7 +57,7 @@
 }
 
 .header-leading-content + .header-content {
-  padding-left: var(--calcite-app-side-spacing-quarter);
+  padding-left: var(--calcite-app-side-spacing-half);
 }
 
 slot[name="header-content"]::slotted(.heading) {

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -53,7 +53,7 @@
 
 .header-content {
   overflow: hidden;
-  padding: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing);
+  padding: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-half);
 }
 
 slot[name="header-content"]::slotted(.heading) {
@@ -61,6 +61,10 @@ slot[name="header-content"]::slotted(.heading) {
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
+}
+
+.header-trailing-content {
+  margin-left: auto;
 }
 
 .content-container {
@@ -75,4 +79,9 @@ slot[name="header-content"]::slotted(.heading) {
   display: flex;
   justify-content: space-evenly;
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
+}
+
+.calcite--rtl .header-trailing-content {
+  margin-left: unset;
+  margin-right: auto;
 }

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -117,11 +117,12 @@ export class CalcitePanel {
   // --------------------------------------------------------------------------
 
   renderHeaderLeadingContent(): VNode {
-    return (
+    const hasLeadingContent = this.el.querySelector(`[slot=${SLOTS.headerLeadingContent}]`);
+    return hasLeadingContent ? (
       <div key="header-leading-content" class={CSS.headerLeadingContent}>
         <slot name={SLOTS.headerLeadingContent} />
       </div>
-    );
+    ) : null;
   }
 
   renderHeaderContent(): VNode {


### PR DESCRIPTION
**Related Issue:** #547 

## Summary
* Added a ternary to only render `header-leading-content` node when slot has content
* Updated related styles
* Includes a small fix for #554 

## Before
![image](https://user-images.githubusercontent.com/12503298/68873584-b3e17a80-06b4-11ea-9296-1b1a570836a0.png)


### After
![image](https://user-images.githubusercontent.com/12503298/68873460-8bf21700-06b4-11ea-998a-ad2bed2de782.png)

