### PR TITLE
fix(action): focus outline a11y

### DIFF
--- a/src/assets/styles/_layout.scss
+++ b/src/assets/styles/_layout.scss
@@ -37,6 +37,8 @@ $cap-spacing: 16px !default;
 
   --calcite-app-header-min-height: calc(var(--calcite-app-cap-spacing) * 3);
 
+  --calcite-app-outline-inset: -3px;
+
   // shadows
   --calcite-app-shadow-0: 0 2px 4px rgba(0, 0, 0, 0.1);
   --calcite-app-shadow-1: #{$shadow-1};

--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -9,6 +9,7 @@
   color: var(--calcite-app-foreground);
   fill: var(--calcite-app-foreground);
   background-color: var(--calcite-app-background);
+  outline-offset: var(--calcite-app-outline-inset);
   padding: var(--calcite-app-cap-spacing) var(--calcite-app-side-spacing);
   margin: 0;
   justify-content: flex-start;


### PR DESCRIPTION
**Related Issue:** #569

## Summary
Outline inset some to make sure focus is visible when action buttons are right next to each other.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

@driskull @jcfranco  Hoping this can get into a patch for the beta. JB brought it to our attention.
