### PR TITLE
Lists: added tests to validate event data

### DIFF
--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.e2e.ts
@@ -26,4 +26,29 @@ describe("calcite-pick-list-item", () => {
     await item.click();
     expect(await item.getProperty("selected")).toBe(false);
   });
+
+  it("should fire event calciteListItemChange when item is clicked", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-pick-list-item text-label="test" value="example"></calcite-pick-list-item>`);
+    const item = await page.find("calcite-pick-list-item");
+    await page.evaluate(() => {
+      document.addEventListener("calciteListItemChange", (event: CustomEvent) => {
+        (window as any).eventDetail = event.detail;
+      });
+    });
+
+    await item.click();
+
+    await page.waitForChanges();
+
+    const eventDetail: any = await page.evaluateHandle(() => {
+      return (window as any).eventDetail;
+    });
+    const properties = await eventDetail.getProperties();
+    expect(properties.get("item")).toBeDefined();
+    expect(properties.get("value")._remoteObject.value).toBe("example");
+    expect(properties.get("selected")._remoteObject.value).toBe(true);
+    expect(properties.get("shiftPressed")._remoteObject.value).toBe(false);
+  });
 });

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -89,6 +89,37 @@ export const tests = {
         expect(numSelected).toBe(3);
       });
     });
+    describe("calciteListChange event", () => {
+      it("should fire event when a selection changed", async () => {
+        const page = await newE2EPage();
+
+        await page.setContent(`<calcite-${listType}-list>
+          <calcite-${listType}-list-item text-label="test" value="example"></calcite-${listType}-list-item>
+        </calcite-${listType}-list>`);
+        const item = await page.find(`calcite-${listType}-list-item`);
+        await page.evaluate(() => {
+          document.addEventListener("calciteListChange", (event: CustomEvent) => {
+            (window as any).eventDetail = event.detail;
+          });
+        });
+
+        await item.click();
+
+        await page.waitForChanges();
+
+        const eventDetail: any = await page.evaluateHandle(() => {
+          const detail = (window as any).eventDetail;
+          return {
+            size: detail.size,
+            hasItem: detail.has("example")
+          };
+        });
+        const properties = await eventDetail.getProperties();
+        expect(eventDetail).toBeDefined();
+        expect(properties.get("size")._remoteObject.value).toBe(1);
+        expect(properties.get("hasItem")._remoteObject.value).toBe(true);
+      });
+    });
   },
   filterBehavior(listType: "pick" | "value") {
     let page: E2EPage = null;


### PR DESCRIPTION
**Related Issue:** #423 

## Summary

Previous tests were only validating the event was called. This validates the event detail object for the two event types is what's expected. This should help avoid bugs being introduced where the event data is modified unintentionally.
