### PR TITLE
test(a11y): wire up missing accessible tests.

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -87,7 +87,7 @@ describe("calcite-action-bar", () => {
     expect(textDisplay).toBe("visible");
   });
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
     <calcite-action-bar>
       <calcite-action-group>
@@ -98,10 +98,9 @@ describe("calcite-action-bar", () => {
         </calcite-action>
       </calcite-action-group>
     </calcite-action-bar>
-    `);
-  });
+    `));
 
-  it("should be accessible when expanded", async () => {
+  it("should be accessible when expanded", async () =>
     accessible(`
     <calcite-action-bar expanded>
       <calcite-action-group>
@@ -112,6 +111,5 @@ describe("calcite-action-bar", () => {
         </calcite-action>
       </calcite-action-group>
     </calcite-action-bar>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-action-group/calcite-action-group.e2e.ts
+++ b/src/components/calcite-action-group/calcite-action-group.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-action-group", () => {
 
   it("honors hidden attribute", async () => hidden("calcite-action-group"));
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
     <calcite-action-group>
         <calcite-action text="Add">
@@ -14,6 +14,5 @@ describe("calcite-action-group", () => {
           </svg>
         </calcite-action>
       </calcite-action-group>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
@@ -5,7 +5,7 @@ describe("calcite-action-pad", () => {
 
   it("honors hidden attribute", async () => hidden("calcite-action-pad"));
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
     <calcite-action-pad>
       <calcite-action-group>
@@ -16,6 +16,5 @@ describe("calcite-action-pad", () => {
         </calcite-action>
       </calcite-action-group>
     </calcite-action-pad>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-action/calcite-action.e2e.ts
+++ b/src/components/calcite-action/calcite-action.e2e.ts
@@ -100,8 +100,8 @@ describe("calcite-action", () => {
   });
 
   it("should be accessible", async () => {
-    accessible(`<calcite-action text="hello world" label="hi"></calcite-action>`);
+    await accessible(`<calcite-action text="hello world" label="hi"></calcite-action>`);
 
-    accessible(`<calcite-action text="hello world" label="hi" disabled text-display="visible"></calcite-action>`);
+    await accessible(`<calcite-action text="hello world" label="hi" disabled text-display="visible"></calcite-action>`);
   });
 });

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -137,8 +137,8 @@ export class CalciteAction {
           title={labelFallback}
           aria-label={labelFallback}
           disabled={disabled}
-          aria-disabled={disabled}
-          aria-busy={loading}
+          aria-disabled={disabled.toString()}
+          aria-busy={loading.toString()}
         >
           {iconContainerNode}
           {textContainerNode}

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -9,6 +9,9 @@ import { CSS } from "./resources";
 import { CSS_UTILITY } from "../utils/resources";
 
 import { getElementDir } from "../utils/dom";
+import { VNode } from "@esri/calcite-components/dist/types/stencil.core";
+
+type TextDisplay = "hidden" | "visible" | "interactive";
 
 @Component({
   tag: "calcite-action",
@@ -67,7 +70,7 @@ export class CalciteAction {
   /**
    * Indicates whether the text is displayed.
    */
-  @Prop({ reflect: true }) textDisplay: "hidden" | "visible" | "interactive" = "hidden";
+  @Prop({ reflect: true }) textDisplay: TextDisplay = "hidden";
 
   /**
    * Used to set the component's color scheme.
@@ -84,12 +87,22 @@ export class CalciteAction {
 
   // --------------------------------------------------------------------------
   //
-  //  Component Methods
+  //  Render Methods
   //
   // --------------------------------------------------------------------------
 
-  render() {
-    const { compact, disabled, loading, el, textEnabled, textDisplay, label, text } = this;
+  renderTextContainer(textDisplay: TextDisplay): VNode {
+    const { text } = this;
+
+    return textDisplay !== "hidden" ? (
+      <div key="text-container" class={CSS.textContainer}>
+        {text}
+      </div>
+    ) : null;
+  }
+
+  renderIconContainer(): VNode {
+    const { loading } = this;
 
     const slotContainerNode = (
       <div
@@ -103,24 +116,19 @@ export class CalciteAction {
 
     const calciteLoaderNode = loading ? <calcite-loader is-active inline></calcite-loader> : null;
 
-    const iconContainerNode = (
+    return (
       <div key="icon-container" aria-hidden="true" class={CSS.iconContainer}>
         {slotContainerNode}
         {calciteLoaderNode}
       </div>
     );
+  }
+
+  render() {
+    const { compact, disabled, loading, el, textEnabled, textDisplay, label, text } = this;
 
     const calculatedTextDisplay = textEnabled ? "visible" : textDisplay;
-
-    const textContainerNode =
-      calculatedTextDisplay !== "hidden" ? (
-        <div key="text-container" class={CSS.textContainer}>
-          {text}
-        </div>
-      ) : null;
-
     const labelFallback = label || text;
-
     const rtl = getElementDir(el) === "rtl";
 
     const buttonClasses = {
@@ -140,8 +148,8 @@ export class CalciteAction {
           aria-disabled={disabled.toString()}
           aria-busy={loading.toString()}
         >
-          {iconContainerNode}
-          {textContainerNode}
+          {this.renderIconContainer()}
+          {this.renderTextContainer(calculatedTextDisplay)}
         </button>
       </Host>
     );

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -119,7 +119,7 @@ export class CalciteBlockSection {
       );
 
     return (
-      <section aria-expanded={open ? "true" : "false"}>
+      <section aria-expanded={open.toString()}>
         {headerNode}
         <div class={CSS.content} hidden={!open}>
           <slot />

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -185,7 +185,7 @@ export class CalciteBlock {
 
     return (
       <Host>
-        <article aria-expanded={collapsible ? (open ? "true" : "false") : null} aria-busy={loading}>
+        <article aria-expanded={collapsible ? open.toString() : null} aria-busy={loading}>
           {headerNode}
           <div class={CSS.content} hidden={!hasContent || !open}>
             <CalciteScrim loading={loading} disabled={disabled}>

--- a/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
+++ b/src/components/calcite-flow-item/calcite-flow-item.e2e.ts
@@ -191,7 +191,7 @@ describe("calcite-flow-item", () => {
     expect(eventSpy).toHaveReceivedEvent();
   });
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
       <calcite-flow-item heading="hello world" menu-open show-back-button>
         <div slot="menu-actions">
@@ -209,6 +209,5 @@ describe("calcite-flow-item", () => {
           </calcite-action>
         </div>
       </calcite-flow-item>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
+import { VNode } from "@stencil/core/dist/declarations";
 
 import { chevronLeft16F, chevronRight16F, ellipsis16 } from "@esri/calcite-ui-icons";
 
@@ -112,7 +113,7 @@ export class CalciteFlowItem {
   //
   // --------------------------------------------------------------------------
 
-  renderBackButton(rtl: boolean) {
+  renderBackButton(rtl: boolean): VNode {
     const { showBackButton, textBack, backButtonClick } = this;
 
     const path = rtl ? chevronRight16F : chevronLeft16F;
@@ -131,7 +132,7 @@ export class CalciteFlowItem {
     ) : null;
   }
 
-  renderMenuButton() {
+  renderMenuButton(): VNode {
     const { menuOpen, textOpen, textClose } = this;
 
     const menuLabel = menuOpen ? textClose : textOpen;
@@ -148,7 +149,7 @@ export class CalciteFlowItem {
     );
   }
 
-  renderMenuActions() {
+  renderMenuActions(): VNode {
     const { menuOpen } = this;
 
     return (
@@ -158,7 +159,7 @@ export class CalciteFlowItem {
     );
   }
 
-  renderFooterActions() {
+  renderFooterActions(): VNode {
     const hasFooterActions = !!this.el.querySelector("[slot=footer-actions]");
 
     return hasFooterActions ? (
@@ -168,7 +169,7 @@ export class CalciteFlowItem {
     ) : null;
   }
 
-  renderSingleActionContainer() {
+  renderSingleActionContainer(): VNode {
     return (
       <div class={CSS.singleActionContainer}>
         <slot name="menu-actions" />
@@ -176,7 +177,7 @@ export class CalciteFlowItem {
     );
   }
 
-  renderMenuActionsContainer() {
+  renderMenuActionsContainer(): VNode {
     return (
       <div class={CSS.menuContainer}>
         {this.renderMenuButton()}
@@ -185,7 +186,7 @@ export class CalciteFlowItem {
     );
   }
 
-  renderHeaderActions() {
+  renderHeaderActions(): VNode {
     const menuActionsNode = this.el.querySelector("[slot=menu-actions]");
 
     const hasMenuActionsInBlacklisted =
@@ -204,8 +205,18 @@ export class CalciteFlowItem {
     return menuActionsNodes ? <div slot="header-trailing-content">{menuActionsNodes}</div> : null;
   }
 
+  renderHeading(): VNode {
+    const { heading } = this;
+
+    return heading ? (
+      <h2 class={CSS.heading} slot="header-content">
+        {heading}
+      </h2>
+    ) : null;
+  }
+
   render() {
-    const { el, heading } = this;
+    const { el } = this;
 
     const rtl = getElementDir(el) === "rtl";
 
@@ -213,9 +224,7 @@ export class CalciteFlowItem {
       <Host>
         <calcite-panel loading={this.loading} disabled={this.disabled}>
           {this.renderBackButton(rtl)}
-          <h2 class={CSS.heading} slot="header-content">
-            {heading}
-          </h2>
+          {this.renderHeading()}
           {this.renderHeaderActions()}
           <slot />
           {this.renderFooterActions()}

--- a/src/components/calcite-flow/calcite-flow.e2e.ts
+++ b/src/components/calcite-flow/calcite-flow.e2e.ts
@@ -143,7 +143,7 @@ describe("calcite-flow", () => {
     expect(showBackButton2).not.toBe(null);
   });
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
     <calcite-flow>
       <calcite-flow-item>
@@ -153,6 +153,5 @@ describe("calcite-flow", () => {
       <calcite-flow-item>
       </calcite-flow-item>
     </calcite-flow>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-panel/calcite-panel.e2e.ts
+++ b/src/components/calcite-panel/calcite-panel.e2e.ts
@@ -40,7 +40,7 @@ describe("calcite-panel", () => {
     expect(eventSpy).toHaveReceivedEvent();
   });
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
     <calcite-panel>
       <div slot="header-leading-content">test L</div>
@@ -49,6 +49,5 @@ describe("calcite-panel", () => {
       <p>Content</p>
       <div slot="footer">test Footer</div>
     </calcite-panel>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -197,7 +197,7 @@ export class CalcitePanel {
     return (
       <Host>
         <article
-          aria-busy={loading}
+          aria-busy={loading.toString()}
           onKeyUp={panelKeyUpHandler}
           tabIndex={dismissible ? 0 : -1}
           hidden={dismissible && dismissed}

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -213,7 +213,7 @@ export class CalcitePickListItem {
       ) : null;
 
     return (
-      <Host role="checkbox" aria-checked={this.selected}>
+      <Host role="checkbox" aria-checked={this.selected.toString()}>
         <label
           class={CSS.label}
           onClick={this.pickListClickHandler}

--- a/src/components/calcite-pick-list/shared-list-render.tsx
+++ b/src/components/calcite-pick-list/shared-list-render.tsx
@@ -11,7 +11,7 @@ export const List = ({ props, text, ...rest }): VNode => {
   const { disabled, loading, filterEnabled, dataForFilter, handleFilter } = props;
   const { filterPlaceholder } = text;
   return (
-    <Host aria-disabled={disabled} aria-busy={loading} {...rest}>
+    <Host aria-disabled={disabled.toString()} aria-busy={loading.toString()} {...rest}>
       <header class={{ [CSS.sticky]: true }}>
         {filterEnabled ? (
           <calcite-filter

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -106,7 +106,7 @@ describe("calcite-shell-panel", () => {
     expect(element.shadowRoot.firstElementChild.tagName).toBe("DIV");
   });
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
     <calcite-shell-panel slot="primary-panel" layout="leading">
       <calcite-action-bar slot="action-bar">
@@ -134,6 +134,5 @@ describe("calcite-shell-panel", () => {
       </calcite-action-bar>
       <p>Primary Content</p>
     </calcite-shell-panel>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -38,7 +38,7 @@ describe("calcite-shell", () => {
     expect(header).not.toBeNull();
   });
 
-  it("should be accessible", async () => {
+  it("should be accessible", async () =>
     accessible(`
     <calcite-shell>
       <calcite-shell-panel slot="primary-panel" layout="leading">
@@ -48,6 +48,5 @@ describe("calcite-shell", () => {
         <p>Primary Content</p>
       </calcite-shell-panel>
     </calcite-shell>
-    `);
-  });
+    `));
 });

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -272,7 +272,7 @@ export class CalciteTipManager {
         <div
           class={CSS.container}
           hidden={closed}
-          aria-hidden={closed}
+          aria-hidden={closed.toString()}
           tabIndex={0}
           onKeyUp={this.tipManagerKeyUpHandler}
           ref={this.storeContainerRef}

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -125,7 +125,7 @@ export class CalciteValueListItem {
           class={{ [CSS.handle]: true, [CSS.handleActivated]: this.handleActivated }}
           tabindex="0"
           data-js-handle="true"
-          aria-pressed={this.handleActivated}
+          aria-pressed={this.handleActivated.toString()}
           onKeyDown={this.handleKeyDown}
           onBlur={this.handleBlur}
         >


### PR DESCRIPTION
**Related Issue:** #587 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

- [x] Restores `accessible` helper
- [x] Fixes failing tests