### PR TITLE
chore: Enable more style linting rules.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,12 +1,16 @@
 {
   "extends": "stylelint-config-recommended-scss",
   "rules": {
+    "declaration-block-semicolon-newline-after": "always-multi-line",
+    "declaration-colon-space-after": "always",
     "no-descending-specificity": null,
+    "property-case": "lower",
     "selector-type-no-unknown": [
       true,
       {
         "ignoreTypes": ["/^calcite-/"]
       }
-    ]
+    ],
+    "unit-case": "lower"
   }
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This enables a few more rules as discussed in a previous sync-up meeting.
