### PR TITLE
chore: Move Flow type to interfaces.ts

### DIFF
--- a/src/components/calcite-flow/calcite-flow.tsx
+++ b/src/components/calcite-flow/calcite-flow.tsx
@@ -1,8 +1,8 @@
 import { Component, Element, Host, Method, Prop, State, h } from "@stencil/core";
 
-import { CSS, FlowDirection } from "./resources";
+import { CSS } from "./resources";
 
-import { CalciteTheme } from "../interfaces";
+import { CalciteTheme, FlowDirection } from "../interfaces";
 
 @Component({
   tag: "calcite-flow",

--- a/src/components/calcite-flow/resources.ts
+++ b/src/components/calcite-flow/resources.ts
@@ -3,5 +3,3 @@ export const CSS = {
   frameAdvancing: "frame--advancing",
   frameRetreating: "frame--retreating"
 };
-
-export type FlowDirection = "advancing" | "retreating";

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -5,3 +5,5 @@ export type CalciteLayout = "leading" | "trailing";
 export type CalciteTheme = "light" | "dark";
 
 export type CalciteBlockSectionToggleDisplay = "button" | "switch";
+
+export type FlowDirection = "advancing" | "retreating";


### PR DESCRIPTION
**Related Issue:** None

## Summary

chore: Move Flow type to interfaces.ts
