### PR TITLE
fix: demo pages in IE11

### DIFF
--- a/src/demos/demoPageReloader.js
+++ b/src/demos/demoPageReloader.js
@@ -4,15 +4,11 @@
     return location.protocol === "https:" ? "wss:" : "ws:" + "//" + location.hostname + ":" + location.port + "/";
   };
 
-  const HOST_WHITELIST = ["localhost", "127.0.0.1"];
+  const clientWebSocket = new window.WebSocket(getSocketUrl(window.location), ["xmpp"]);
 
-  if(HOST_WHITELIST.indexOf(location.hostname) !== -1 && "WebSocket" in window){
-    const clientWebSocket = new window.WebSocket(getSocketUrl(window.location), ["xmpp"]);
-
-    clientWebSocket.addEventListener("message", function(message) {
-      if (message.data.indexOf("rebuild finished") > -1) {
-        window.location.reload();
-      }
-    });
-  }
+  clientWebSocket.addEventListener("message", function(message) {
+    if (message.data.indexOf("rebuild finished") > -1) {
+      window.location.reload();
+    }
+  });
 })();

--- a/src/demos/demoPageReloader.js
+++ b/src/demos/demoPageReloader.js
@@ -4,11 +4,15 @@
     return location.protocol === "https:" ? "wss:" : "ws:" + "//" + location.hostname + ":" + location.port + "/";
   };
 
-  const clientWebSocket = new window.WebSocket(getSocketUrl(window.location), ["xmpp"]);
+  const HOST_WHITELIST = ["localhost", "127.0.0.1"];
 
-  clientWebSocket.addEventListener("message", function(message) {
-    if (message.data.indexOf("rebuild finished") > -1) {
-      window.location.reload();
-    }
-  });
+  if(HOST_WHITELIST.indexOf(location.hostname) !== -1 && "WebSocket" in window){
+    const clientWebSocket = new window.WebSocket(getSocketUrl(window.location), ["xmpp"]);
+
+    clientWebSocket.addEventListener("message", function(message) {
+      if (message.data.indexOf("rebuild finished") > -1) {
+        window.location.reload();
+      }
+    });
+  }
 })();

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -1,32 +1,57 @@
 (function() {
-  const root = window.location.pathname.split("demos").shift();
+  const CSS = ["demos/demos.css", "build/calcite-app.css", "vendor/@esri/calcite-components/calcite.css"];
+
+  const DEV_SCRIPTS = [
+    {
+      src: "demos/toggles.js"
+    },
+    {
+      src: "demos/demoPageReloader.js"
+    }
+  ];
+
+  const CALCITE_SCRIPTS = [
+    {
+      src: "build/calcite-app.esm.js",
+      type: "module"
+    },
+    {
+      src: "build/calcite-app.js",
+      noModule: true
+    },
+    {
+      src: "vendor/@esri/calcite-components/calcite.esm.js",
+      type: "module"
+    },
+    {
+      src: "vendor/@esri/calcite-components/calcite.js",
+      noModule: true
+    }
+  ];
+
+  // Internet Explorer 6-11
+  var isIE = /*@cc_on!@*/ false || !!document.documentMode;
+
+  const SCRIPTS = isIE ? CALCITE_SCRIPTS : DEV_SCRIPTS.concat(CALCITE_SCRIPTS);
+  const ROOT = window.location.pathname.split("demos").shift();
 
   function loadCss(url) {
     let link = document.createElement("link");
     link.rel = "stylesheet";
-    link.href = root + url;
+    link.href = ROOT + url;
     document.head.appendChild(link);
   }
 
-  function loadScript(url, options) {
-    let script = document.createElement("script");
-    if (options) {
-      Object.keys(options).forEach(function(key) {
-        script[key] = options[key];
-      });
-    }
-    script.src = root + url;
+  function loadScript(scriptOptions) {
+    let scriptElement = document.createElement("script");
 
-    document.head.appendChild(script);
+    Object.keys(scriptOptions).forEach(function(key) {
+      scriptElement[key] = key === "src" ? ROOT + scriptOptions[key] : scriptOptions[key];
+    });
+
+    document.head.appendChild(scriptElement);
   }
 
-  loadCss("demos/demos.css");
-  loadCss("build/calcite-app.css");
-  loadCss("vendor/@esri/calcite-components/calcite.css");
-  loadScript("demos/demoPageReloader.js");
-  loadScript("demos/toggles.js");
-  loadScript("build/calcite-app.esm.js", { type: "module" });
-  loadScript("build/calcite-app.js", { noModule: true });
-  loadScript("vendor/@esri/calcite-components/calcite.esm.js", { type: "module" });
-  loadScript("vendor/@esri/calcite-components/calcite.js", { noModule: true });
+  CSS.forEach(loadCss);
+  SCRIPTS.forEach(loadScript);
 })();

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -1,16 +1,7 @@
 (function() {
   const CSS = ["demos/demos.css", "build/calcite-app.css", "vendor/@esri/calcite-components/calcite.css"];
 
-  const DEV_SCRIPTS = [
-    {
-      src: "demos/toggles.js"
-    },
-    {
-      src: "demos/demoPageReloader.js"
-    }
-  ];
-
-  const CALCITE_SCRIPTS = [
+  const SCRIPTS = [
     {
       src: "build/calcite-app.esm.js",
       type: "module"
@@ -31,10 +22,19 @@
 
   const DEV_HOST_WHITELIST = ["localhost", "127.0.0.1"];
 
-  const isIE = /*@cc_on!@*/ false || !!document.documentMode; // Internet Explorer 6-11
-  const loadDevScripts = !isIE && DEV_HOST_WHITELIST.indexOf(location.host) !== -1;
+  if (DEV_HOST_WHITELIST.indexOf(location.host) !== -1) {
+    SCRIPTS.push({
+      src: "demos/demoPageReloader.js"
+    });
+  }
 
-  const SCRIPTS = loadDevScripts ? DEV_SCRIPTS.concat(CALCITE_SCRIPTS) : CALCITE_SCRIPTS;
+  // Internet Explorer 6-11
+  if (/*@cc_on!@*/ false || !!document.documentMode) {
+    SCRIPTS.push({
+      src: "demos/toggles.js"
+    });
+  }
+
   const ROOT = window.location.pathname.split("demos").shift();
 
   function loadCss(url) {
@@ -44,11 +44,11 @@
     document.head.appendChild(link);
   }
 
-  function loadScript(scriptOptions) {
+  function loadScript(options) {
     let scriptElement = document.createElement("script");
 
-    Object.keys(scriptOptions).forEach(function(key) {
-      scriptElement[key] = key === "src" ? ROOT + scriptOptions[key] : scriptOptions[key];
+    Object.keys(options).forEach(function(key) {
+      scriptElement[key] = key === "src" ? ROOT + options[key] : options[key];
     });
 
     document.head.appendChild(scriptElement);

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -20,6 +20,7 @@
     }
   ];
 
+  // Assume server is running in a development environment if there is a port present in the URL and reload demo pages.
   if (location.port) {
     SCRIPTS.push({
       src: "demos/demoPageReloader.js"

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -29,10 +29,12 @@
     }
   ];
 
-  // Internet Explorer 6-11
-  var isIE = /*@cc_on!@*/ false || !!document.documentMode;
+  const DEV_HOST_WHITELIST = ["localhost", "127.0.0.1"];
 
-  const SCRIPTS = isIE ? CALCITE_SCRIPTS : DEV_SCRIPTS.concat(CALCITE_SCRIPTS);
+  const isIE = /*@cc_on!@*/ false || !!document.documentMode; // Internet Explorer 6-11
+  const loadDevScripts = !isIE && DEV_HOST_WHITELIST.indexOf(location.host) !== -1;
+
+  const SCRIPTS = loadDevScripts ? DEV_SCRIPTS.concat(CALCITE_SCRIPTS) : CALCITE_SCRIPTS;
   const ROOT = window.location.pathname.split("demos").shift();
 
   function loadCss(url) {

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -20,16 +20,15 @@
     }
   ];
 
-  const DEV_HOST_WHITELIST = ["localhost", "127.0.0.1"];
-
-  if (DEV_HOST_WHITELIST.indexOf(location.host) !== -1) {
+  if (location.port >= 3333 && location.port < 4000) {
     SCRIPTS.push({
       src: "demos/demoPageReloader.js"
     });
   }
 
-  // Internet Explorer 6-11
-  if (/*@cc_on!@*/ false || !!document.documentMode) {
+  const IS_IE = /*@cc_on!@*/ false || !!document.documentMode; // Internet Explorer 6-11
+
+  if (!IS_IE) {
     SCRIPTS.push({
       src: "demos/toggles.js"
     });

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -20,7 +20,7 @@
     }
   ];
 
-  if (location.port >= 3333 && location.port < 3340) {
+  if (location.port) {
     SCRIPTS.push({
       src: "demos/demoPageReloader.js"
     });

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -20,7 +20,7 @@
     }
   ];
 
-  if (location.port >= 3333 && location.port < 4000) {
+  if (location.port >= 3333 && location.port < 3340) {
     SCRIPTS.push({
       src: "demos/demoPageReloader.js"
     });

--- a/src/demos/head.js
+++ b/src/demos/head.js
@@ -26,9 +26,9 @@
     });
   }
 
-  const IS_IE = /*@cc_on!@*/ false || !!document.documentMode; // Internet Explorer 6-11
+  const IS_IE11 = /Trident.*rv[ :]*11\./.test(navigator.userAgent);
 
-  if (!IS_IE) {
+  if (!IS_IE11) {
     SCRIPTS.push({
       src: "demos/toggles.js"
     });


### PR DESCRIPTION
**Related Issue:** None

fix: demo pages in IE11

- Only loads demopagereloader script if port 3333-3339
- Only loads toggles script if not IE (We can load this if its rewritten with IE support)
- Cleanup