### PR TITLE
fix(value-list-item): focus outline for handle

### DIFF
--- a/src/components/calcite-value-list-item/calcite-value-list-item.scss
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.scss
@@ -35,6 +35,7 @@ calcite-pick-list-item[selected],
   line-height: 0;
   cursor: move;
   @include borderShadow();
+  @include focusRingInset();
   &:focus {
     outline-offset: var(--calcite-app-outline-inset);
   }


### PR DESCRIPTION
**Related Issue:** #573 

## Summary
Focus ring for value-list-item handle.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
