### PR TITLE
fix: keep value-list-item selected in sync with pick-list-item

### DIFF
--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -112,6 +112,7 @@ export class CalciteFilter {
         <label>
           <input
             type="text"
+            value=""
             placeholder={this.textPlaceholder}
             onInput={this.inputHandler}
             aria-label={this.textLabel || TEXT.filterLabel}

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -110,6 +110,10 @@ export class CalciteValueListItem {
     this.handleActivated = false;
   };
 
+  handleSelectChange = (event: CustomEvent) => {
+    this.selected = event.detail.selected;
+  };
+
   // --------------------------------------------------------------------------
   //
   //  Render Methods
@@ -148,6 +152,7 @@ export class CalciteValueListItem {
           metadata={this.metadata}
           textLabel={this.textLabel}
           textDescription={this.textDescription}
+          onCalciteListItemChange={this.handleSelectChange}
           value={this.value}
         >
           <slot name="secondaryAction" slot="secondaryAction" />


### PR DESCRIPTION
**Related Issue:** None

## Summary

- Keep value-list-item selected in sync with pick-list-item
- Add value to input. warning from stencil dev server `[STENCIL-DEV-MODE] The "value" prop of <input> should be set after "min", "max", "type" and "step"`
