### PR TITLE
chore: deprecate "textDisplay" in favor of "textEnabled"

### DIFF
--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -61,12 +61,12 @@ export class CalciteAction {
   @Prop() text: string;
 
   /**
-   * @deprecated Use 'textDisplay' instead.
+   * Indicates whether the text is displayed.
    */
   @Prop() textEnabled = false;
 
   /**
-   * Indicates whether the text is displayed.
+   * @deprecated Use 'textEnabled' instead.
    */
   @Prop({ reflect: true }) textDisplay: TextDisplay = "hidden";
 


### PR DESCRIPTION
**Related Issue:** None

## Summary

chore: deprecate "textDisplay" in favor of "textEnabled"
