### PR TITLE
fix(panel): add min-heights for panel header and footer

### DIFF
--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -17,7 +17,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-basis: var(--calcite-app-header-min-height);
   color: var(--calcite-app-foreground);
   fill: var(--calcite-app-foreground);
 }

--- a/src/assets/styles/_layout.scss
+++ b/src/assets/styles/_layout.scss
@@ -33,6 +33,7 @@
   --calcite-app-border-radius: 3px;
 
   --calcite-app-header-min-height: calc(var(--calcite-app-cap-spacing) * 3);
+  --calcite-app-footer-min-height: calc(var(--calcite-app-cap-spacing) * 3);
 
   --calcite-app-outline-inset: -4px;
 

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -43,7 +43,9 @@
 .header {
   align-items: center;
   display: flex;
+  flex: 1 0 auto;
   justify-content: space-between;
+  min-height: var(--calcite-app-header-min-height);
   position: relative;
   z-index: 2;
   border-bottom: 1px solid var(--calcite-app-border);
@@ -55,6 +57,10 @@
   padding: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing);
 }
 
+.header-leading-content,
+.header-trailing-content {
+  margin-bottom: var(--calcite-app-cap-spacing-minimum);
+}
 .header-leading-content + .header-content {
   padding-left: var(--calcite-app-side-spacing-half);
 }
@@ -79,7 +85,9 @@ slot[name="header-content"]::slotted(.heading) {
 .footer {
   border-top: 1px solid var(--calcite-app-border);
   display: flex;
+  flex: 1 0 auto;
   justify-content: space-evenly;
+  min-height: var(--calcite-app-footer-min-height);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
 }
 


### PR DESCRIPTION
**Related Issue:** #565

## Summary
Partial fix. Developer will still need to only set heights on flow or container when in popover.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

cc @AdelheidF 