### PR TITLE
fix(panel): flex grow, shrink, basis for panel headers and footers

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -43,7 +43,7 @@
 .header {
   align-items: center;
   display: flex;
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   justify-content: space-between;
   min-height: var(--calcite-app-header-min-height);
   position: relative;
@@ -85,7 +85,7 @@ slot[name="header-content"]::slotted(.heading) {
 .footer {
   border-top: 1px solid var(--calcite-app-border);
   display: flex;
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   justify-content: space-evenly;
   min-height: var(--calcite-app-footer-min-height);
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);


### PR DESCRIPTION
**Related Issue:** #642

## Summary
Added better flex grow, shrink, basis for panel header and footer.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

@driskull 
Could use a patch for this one.