### PR TITLE
chore(docs): ensure storybook doc build runs fully

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "demoPageSync": "node ./support/demoPageSync.js",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"chore(deps): Bump versions.\"",
     "docs": "stencil build --config stencil.docs.config.ts",
-    "docs:storybook": "concurrently --raw \"npm run build:docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\" \"node ./support/tempDocDirCleaner.js\"",
+    "docs:storybook": "concurrently --kill-others --raw \"npm run build:docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\" \"node ./support/tempDocDirCleaner.js\"",
     "docs:preview": "concurrently --raw \"npm run build:docs && start-storybook --static-dir ./__docs-temp__\" \"node ./support/tempDocDirCleaner.js\"",
     "lint": "npm-run-all --parallel lint:*",
     "lint:ts": "tslint --project tsconfig-tslint.json",

--- a/support/tempDocDirCleaner.js
+++ b/support/tempDocDirCleaner.js
@@ -19,6 +19,10 @@ process.on("exit", exitHandler.bind(null, { cleanup: true }));
 // catches ctrl+c event
 process.on("SIGINT", exitHandler.bind(null, { exit: true }));
 
+// catches other kill process signals (e.g., concurrently --kill-others ...)
+process.on("SIGHUP", exitHandler.bind(null, { exit: true }));
+process.on("SIGTERM", exitHandler.bind(null, { exit: true }));
+
 // catches "kill pid" (for example: nodemon restart)
 process.on("SIGUSR1", exitHandler.bind(null, { exit: true }));
 process.on("SIGUSR2", exitHandler.bind(null, { exit: true }));


### PR DESCRIPTION
**Related Issue:** #401 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

The `docs:storybook` script currently hangs unless it's explicitly terminated (e.g., CTRL+C on Unix).