### PR TITLE
docs(demos): fix docs output

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:docs": "stencil build --config stencil.storybook.config.ts",
     "demoPageSync": "ts-node ./support/demoPageSync.ts",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"chore(deps): Bump versions.\"",
-    "docs": "stencil build --config stencil.docs.config.ts",
+    "docs": "tsc --project ./tsconfig-demos.json && stencil build --config stencil.docs.config.ts",
     "docs:storybook": "concurrently --kill-others --raw \"npm run build:docs && build-storybook --static-dir ./__docs-temp__ --output-dir ./docs\" \"ts-node ./support/tempDocDirCleaner.ts\"",
     "docs:preview": "concurrently --raw \"npm run build:docs && start-storybook --static-dir ./__docs-temp__\" \"ts-node ./support/tempDocDirCleaner.ts\"",
     "lint": "concurrently npm:lint:*",

--- a/stencil.docs.config.ts
+++ b/stencil.docs.config.ts
@@ -6,6 +6,7 @@ export const create: typeof baseConfigCreator = () => {
 
   const wwwOutputTarget = docsConfig.outputTargets.find((element) => element.type === "www") as OutputTargetWww;
   wwwOutputTarget.dir = "docs";
+  docsConfig.outputTargets = [wwwOutputTarget];
 
   docsConfig.excludeSrc = ["**/*.stories.ts", "**/tests/**"];
 

--- a/stencil.storybook.config.ts
+++ b/stencil.storybook.config.ts
@@ -7,6 +7,7 @@ export const create: typeof baseConfigCreator = () => {
   const wwwOutputTarget = docsConfig.outputTargets.find((element) => element.type === "www") as OutputTargetWww;
   wwwOutputTarget.copy = wwwOutputTarget.copy.filter((item) => !item.src.includes("demos"));
   wwwOutputTarget.dir = "__docs-temp__";
+  docsConfig.outputTargets = [wwwOutputTarget];
 
   return docsConfig;
 };


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

* Restores `outputTargets` from doc-specific Stencil configs.
* Builds demo source before building docs.