### PR TITLE
docs(calcite-block): update stories to use property name

### DIFF
--- a/src/components/calcite-block/calcite-block.stories.ts
+++ b/src/components/calcite-block/calcite-block.stories.ts
@@ -55,11 +55,11 @@ const createBlockAttributes: () => Attributes = () => {
     },
     {
       name: "text-collapse",
-      value: text("text-collapse", "Collapse", group)
+      value: text("textCollapse", "Collapse", group)
     },
     {
       name: "text-expand",
-      value: text("text-expand", "Expand", group)
+      value: text("textExpand", "Expand", group)
     }
   ];
 };
@@ -79,15 +79,15 @@ const createSectionAttributes: () => Attributes = () => {
     },
     {
       name: "toggle-display",
-      value: select("toggle-display", toggleDisplayOptions, toggleDisplayOptions[0], group)
+      value: select("toggleDisplay", toggleDisplayOptions, toggleDisplayOptions[0], group)
     },
     {
       name: "text-collapse",
-      value: text("text-collapse", "Collapse", group)
+      value: text("textCollapse", "Collapse", group)
     },
     {
       name: "text-expand",
-      value: text("text-expand", "Expand", group)
+      value: text("textExpand", "Expand", group)
     }
   ];
 };


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Use property names for knobs for consistency.