### PR TITLE
docs(demos): add missing vendor stylesheet

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,9 +1,13 @@
 <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
+
 <link rel="stylesheet" href="build/calcite-app.css" />
 <script type="module" src="build/calcite-app.esm.js"></script>
 <script nomodule="" src="build/calcite-app.js"></script>
+
+<link rel="stylesheet" href="vendor/@esri/calcite-components/calcite.css" />
 <script type="module" src="vendor/@esri/calcite-components/calcite.esm.js"></script>
 <script nomodule="" src="vendor/@esri/calcite-components/calcite.js"></script>
+
 <style>
   /* centered decorator zoom fix - https://github.com/storybookjs/storybook/issues/7167#issuecomment-510876389 */
   html,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Adds missing stylesheet for `@esri/calcite-components`.