### PR TITLE
docs(demos): update HTML helper to add missing quotes for attribute values

### DIFF
--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -52,4 +52,4 @@ export interface SimpleAttribute {
 export type Attributes = (KnobbedAttribute | SimpleAttribute)[];
 
 export const createComponentHTML = (tagName: string, attributes: Attributes, contentHTML?: string) =>
-  `<${tagName} ${attributes.map(({ name, value }) => `${name}=${value}`).join(" ")}>${contentHTML}</${tagName}>`;
+  `<${tagName} ${attributes.map(({ name, value }) => `${name}="${value}"`).join(" ")}>${contentHTML}</${tagName}>`;


### PR DESCRIPTION
**Related Issue:** #675 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Fixes markup generated by `createComponentHTML` helper.