### PR TITLE
fix(panel, shell-panel): flex-flow fix

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   border-radius: var(--calcite-app-border-radius);
-  margin: var(--calcite-app-cap-spacing-third) var(--calcite-app-side-spacing-third);
+  margin: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-quarter) 0;
   @include borderShadow();
 }
 

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -80,6 +80,9 @@ slot[name="header-content"]::slotted(.heading) {
 }
 
 .content-container {
+  align-items: stretch;
+  display: flex;
+  flex-flow: column;
   flex: 1 1 auto;
   background-color: var(--calcite-app-background-content);
   overflow: auto;

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -82,7 +82,7 @@ slot[name="header-content"]::slotted(.heading) {
 .content-container {
   align-items: stretch;
   display: flex;
-  flex-flow: column;
+  flex-flow: column nowrap;
   flex: 1 1 auto;
   background-color: var(--calcite-app-background-content);
   overflow: auto;

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -17,6 +17,7 @@
   align-items: stretch;
   align-self: stretch;
   background-color: var(--calcite-app-background-content);
+  flex-flow: column;
   display: flex;
   width: var(--calcite-app-shell-panel-width);
   min-width: var(--calcite-app-shell-panel-min-width);

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -17,7 +17,7 @@
   align-items: stretch;
   align-self: stretch;
   background-color: var(--calcite-app-background-content);
-  flex-flow: column;
+  flex-flow: column nowrap;
   display: flex;
   width: var(--calcite-app-shell-panel-width);
   min-width: var(--calcite-app-shell-panel-min-width);

--- a/src/demos/shell/demo-app-full-window.html
+++ b/src/demos/shell/demo-app-full-window.html
@@ -120,7 +120,6 @@
                 </calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
-            <div>
               <calcite-block collapsible  heading="Primary Content" summary="This is the primary.">
                 <calcite-block-content>
                   <calcite-action text="Side ActionPad" text-enabled id="action-pad-button" indicator>
@@ -175,7 +174,6 @@
                   </div>
                 </calcite-block-content>
               </calcite-block>
-            </div>
           </calcite-shell-panel>
 
           <calcite-shell-panel slot="contextual-panel" layout="trailing" detached detached-scale="l">


### PR DESCRIPTION
**Related Issue:** #691 

## Summary
- flex-flow rule for panel and shell-panel
- block spacing to take account of margin rendering in flex
- panel styles to ensure spacing stays accurate with blocks
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
