### PR TITLE
docs:  punctuation cleanup

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -7,8 +7,8 @@ import { getElementDir } from "../utils/dom";
 import { CSS, ICONS } from "./resources";
 
 /**
- * @slot bottom-actions - A slot for adding `calcite-actions` that will appear at the bottom of the action bar, above the collapse/expand button.
- * @slot - A slot for adding `calcite-actions` that will appear at the top of the action bar.
+ * @slot bottom-actions - A slot for adding `calcite-action`s that will appear at the bottom of the action bar, above the collapse/expand button.
+ * @slot - A slot for adding `calcite-action`s that will appear at the top of the action bar.
  */
 @Component({
   tag: "calcite-action-bar",
@@ -49,7 +49,8 @@ export class CalciteActionBar {
   @Prop() textCollapse = "Collapse";
 
   /**
-   * Arrangement of the component.
+   * Arrangement of the component. Leading and trailing are different depending on if the direction is LTR or RTL. For example, "leading"
+   * in a LTR app will appear on the left.
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
 

--- a/src/components/calcite-action-bar/readme.md
+++ b/src/components/calcite-action-bar/readme.md
@@ -2,9 +2,7 @@
 
 ## Description
 
-The `calcite-action-bar` component is made up of multiple `calcite-actions` in the form of clickable icons. The action bar can be expanded to view actions with descriptive text or made smaller to view with just icons.
-
-See the [calcite-action-bar demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-action-bar--basic).
+The `calcite-action-bar` component is made up of multiple `calcite-action`s in the form of clickable icons. The action bar can be expanded to view actions with descriptive text or made smaller to view with just icons.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-action-group/calcite-action-group.tsx
+++ b/src/components/calcite-action-group/calcite-action-group.tsx
@@ -6,7 +6,7 @@ import { Component, Host, h } from "@stencil/core";
   shadow: true
 })
 /**
- * @slot - A slot for adding a group of `calcite-actions`.
+ * @slot - A slot for adding a group of `calcite-action`s.
  */
 export class CalciteActionGroup {
   // --------------------------------------------------------------------------

--- a/src/components/calcite-action-group/readme.md
+++ b/src/components/calcite-action-group/readme.md
@@ -1,6 +1,6 @@
 # calcite-action-group
 
-The `calcite-action-group` is a wrapper for multiple `calcite-actions` and housed in `calcite-action-bar` and `calcite-action-pad`.
+The `calcite-action-group` is a wrapper for multiple `calcite-action`s and housed in `calcite-action-bar` and `calcite-action-pad`.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -5,7 +5,7 @@ import { CalciteTheme } from "../interfaces";
 import { CSS } from "./resources";
 
 /**
- * @slot - A slot for adding `calcite-actions` to the action pad.
+ * @slot - A slot for adding `calcite-action`s to the action pad.
  */
 @Component({
   tag: "calcite-action-pad",

--- a/src/components/calcite-action-pad/readme.md
+++ b/src/components/calcite-action-pad/readme.md
@@ -1,8 +1,6 @@
 # calcite-action-pad
 
-The `calcite-action-pad` component is made up of `calcite-actions` in the form of clickable icons. This does not have an expandable option and is a smaller and simpler component than `calcite-action-bar`.
-
-See the [calcite-action-pad demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-action-pad--basic).
+The `calcite-action-pad` component is made up of `calcite-action`s in the form of clickable icons. This does not have an expandable option and is a smaller and simpler component than `calcite-action-bar`.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -46,7 +46,7 @@ export class CalciteAction {
   @Prop({ reflect: true }) indicator = false;
 
   /**
-   * Label of the action, exposed on hover.
+   * Label of the action, exposed on hover. If no label is provided, the label inherits what's provided for the `text` prop.
    */
   @Prop() label: string;
 

--- a/src/components/calcite-action/readme.md
+++ b/src/components/calcite-action/readme.md
@@ -2,8 +2,6 @@
 
 The `calcite-action` component lives in either a `calcite-action-bar` or `calcite-action-pad`. Actions look like an icon with a text description option of the component that will be revealed when the icon/ text is clicked or selected.
 
-See the [calcite-action demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-action--basic).
-
 <!-- Auto Generated Below -->
 
 ## Usage

--- a/src/components/calcite-block-section/readme.md
+++ b/src/components/calcite-block-section/readme.md
@@ -1,6 +1,6 @@
 # calcite-block-section
 
-The `calcite-block-section` component is a child element of `calcite-block`. Sections can have their own header and content be toggled open and closed.
+The `calcite-block-section` component is a child element of `calcite-block`. Sections can have their own header and content and can be toggled open and closed.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-block-section/readme.md
+++ b/src/components/calcite-block-section/readme.md
@@ -1,6 +1,6 @@
 # calcite-block-section
 
-The `calcite-block-section` component is a child element of `calcite-block`. Sections can have their own header and content and can be toggled open and closed.
+The `calcite-block-section` component is a child element of `calcite-block`. Sections can have their own header and content and can be toggled open or closed.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-block/readme.md
+++ b/src/components/calcite-block/readme.md
@@ -1,8 +1,6 @@
 # calcite-block
 
-The `calcite-block` component is intended for displaying content on it's own as well as in stacked, collapsible `calcite-block-sections` in a panel.
-
-See the [calcite-block demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-block--basic).
+The `calcite-block` component is intended for displaying a heading and content. Content can also include stacked, collapsible `calcite-block-section`s typically housed in a panel.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -8,7 +8,7 @@ describe("calcite-filter", () => {
   it("is accessible", async () => accessible(`<calcite-filter></calcite-filter>`));
 
   describe("strings", () => {
-    it.only("should update the filter placeholder when a string is provided", async () => {
+    it("should update the filter placeholder when a string is provided", async () => {
       const page = await newE2EPage();
       const placeholderText = "hide em";
       await page.setContent(`<calcite-filter text-placeholder="${placeholderText}"></calcite-filter>`);
@@ -18,7 +18,7 @@ describe("calcite-filter", () => {
     });
   });
 
-  describe.only("clear button", () => {
+  describe("clear button", () => {
     let page;
     beforeEach(async () => {
       page = await newE2EPage();

--- a/src/components/calcite-flow-item/readme.md
+++ b/src/components/calcite-flow-item/readme.md
@@ -2,8 +2,6 @@
 
 A `calcite-flow-item` is a child element of `calcite-flow` and lives in a panel with a heading and content.
 
-See the [calcite-flow-item demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-flow--basic).
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-flow/calcite-flow.tsx
+++ b/src/components/calcite-flow/calcite-flow.tsx
@@ -7,7 +7,7 @@ import { CalciteTheme, FlowDirection } from "../interfaces";
 import classnames from "classnames";
 
 /**
- * @slot - A slot for adding `calcite-flow-items` to the flow.
+ * @slot - A slot for adding `calcite-flow-item`s to the flow.
  */
 @Component({
   tag: "calcite-flow",

--- a/src/components/calcite-flow/readme.md
+++ b/src/components/calcite-flow/readme.md
@@ -1,8 +1,6 @@
 # calcite-flow
 
-The `calcite-flow` component is a series of panels that provides a user with a workflow (eg. editing experience), by which the user can switch from panel to panel of `calcite-flow-items`.
-
-See the [calcite-flow demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-flow--basic).
+The `calcite-flow` component is a series of panels that provides a user with a workflow (eg. editing experience), by which the user can switch from panel to panel of `calcite-flow-item`s.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-panel/readme.md
+++ b/src/components/calcite-panel/readme.md
@@ -1,6 +1,6 @@
 # calcite-panel
 
-The `calcite-panel` component is a container that for a header, content and optionally a footer. The header will have centered content as well as optional leading and trailing content. The panel can also be setup to be dismissible which will allow it to be closed by a user.
+The `calcite-panel` component is a container for a header, content and optional footer. The header will have centered content as well as optional leading and trailing content. The panel can also be setup to be dismissible which allows it to be closed by a user.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
@@ -2,7 +2,7 @@ import { Component, Host, Prop, h } from "@stencil/core";
 import { CSS } from "./resources";
 
 /**
- * @slot - A slot for adding calcite-pick-list-item elements.
+ * @slot - A slot for adding `calcite-pick-list-item` elements.
  */
 @Component({
   tag: "calcite-pick-list-group",
@@ -17,7 +17,7 @@ export class CalcitePickListGroup {
   // --------------------------------------------------------------------------
 
   /**
-   * The title used for all nested pick-list rows
+   * The title used for all nested `calcite-pick-list` rows
    */
   @Prop({ reflect: true }) textGroupTitle: string;
 

--- a/src/components/calcite-pick-list-group/readme.md
+++ b/src/components/calcite-pick-list-group/readme.md
@@ -1,6 +1,6 @@
 # calcite-pick-list-group
 
-`calcite-pick-list-group` is a wrapper for multiple `calcite-pick-list-items` and housed in `calcite-pick-list`.
+`calcite-pick-list-group` is a wrapper for multiple `calcite-pick-list-item`s and lives in `calcite-pick-list`.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -13,7 +13,8 @@ import { CSS, ICONS } from "./resources";
 import { ICON_TYPES } from "../calcite-pick-list/resources";
 
 /**
- * @slot secondaryAction - A slot intended for adding a calcite-action or calcite-button. Placed at the end of the item.
+ * @slot secondaryAction - A slot intended for adding a `calcite-action` or `calcite-button` to the right side of the card.
+ * This is placed at the end of the item.
  */
 @Component({
   tag: "calcite-pick-list-item",
@@ -28,7 +29,8 @@ export class CalcitePickListItem {
   // --------------------------------------------------------------------------
 
   /**
-   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute. This allows for a more compact version of the pick-list-item.
+   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute.
+   * This allows for a more compact version of the `calcite-pick-list-item`.
    */
   @Prop({ reflect: true }) compact? = false;
 

--- a/src/components/calcite-pick-list-item/readme.md
+++ b/src/components/calcite-pick-list-item/readme.md
@@ -1,6 +1,6 @@
 # calcite-pick-list-item
 
-`calcite-pick-list-items` are cards contained in a `calcite-pick-list`. They each can have a label and description, an icon, and be set to compact. The developer can disable or preselect each list item and give it a value.
+`calcite-pick-list-item`s are cards contained in a `calcite-pick-list`. They each can have a label and description, an icon, and be set to compact. The developer can disable or preselect each list item and give it a value.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -27,7 +27,7 @@ const {
 } = sharedListMethods;
 
 /**
- * @slot - A slot for adding pick-list-item elements or pick-list-groups elements. Items are displayed as a vertical list.
+ * @slot - A slot for adding `pick-list-item` elements or pick-list-groups elements. Items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
  */
 @Component({
@@ -44,7 +44,7 @@ export class CalcitePickList {
 
   /**
    * Compact removes the selection icon (radio or checkbox) and adds a compact attribute.
-   * This allows for a more compact version of the pick-list-item.
+   * This allows for a more compact version of the `pick-list-item`.
    */
   @Prop({ reflect: true }) compact = false;
 

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -44,7 +44,7 @@ export class CalcitePickList {
 
   /**
    * Compact removes the selection icon (radio or checkbox) and adds a compact attribute.
-   * This allows for a more compact version of the `pick-list-item`.
+   * This allows for a more compact version of the `calcite-pick-list-item`.
    */
   @Prop({ reflect: true }) compact = false;
 

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -27,7 +27,7 @@ const {
 } = sharedListMethods;
 
 /**
- * @slot - A slot for adding `pick-list-item` elements or pick-list-groups elements. Items are displayed as a vertical list.
+ * @slot - A slot for adding `calcite-pick-list-item` elements or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
  */
 @Component({

--- a/src/components/calcite-pick-list/readme.md
+++ b/src/components/calcite-pick-list/readme.md
@@ -1,6 +1,6 @@
 # calcite-pick-list
 
-`calcite-pick-list` is housed in a panel and contains `calcite-pick-list-items`. Each item is able to be be selected via radio button or checkboxes (which have a multiselect and shift-click capability). There is also an option for a filter at the top of the list for searching.
+`calcite-pick-list` lives in a panel and contains `calcite-pick-list-item`s. Each item is able to be be selected via radio button or checkboxes (which have a multiselect and shift-click capability). There is also an option for a filter at the top of the list for searching.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-shell-panel/readme.md
+++ b/src/components/calcite-shell-panel/readme.md
@@ -1,8 +1,6 @@
 # calcite-shell-panel
 
-The `calcite-shell-panel` is a child component of `calcite-shell` used to house and display other components like `calcite-block` and `calcite-flow`.
-
-See the [calcite-shell-panel demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-shell--basic).
+The `calcite-shell-panel` is a child component of `calcite-shell` used as a container to display other components like `calcite-block` and `calcite-flow`.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-shell/readme.md
+++ b/src/components/calcite-shell/readme.md
@@ -4,8 +4,6 @@ The `calcite-shell` component is used for application layout management. It is a
 
 _note: calcite-shell supports tablet as the smallest screen size_
 
-See the [calcite-shell demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-shell--basic).
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-tip-group/readme.md
+++ b/src/components/calcite-tip-group/readme.md
@@ -1,6 +1,6 @@
 # calcite-tip-group
 
-`Calcite-tip-group` is a wrapper for multiple `calcite-tips` and is housed in `calcite-tip-manager`.
+`calcite-tip-group` is a wrapper for multiple `calcite-tip`s and is housed in `calcite-tip-manager`.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -16,7 +16,7 @@ import { getElementDir } from "../utils/dom";
 import { CalciteTheme } from "../interfaces";
 
 /**
- * @slot - A slot for adding `calcite-tips`.
+ * @slot - A slot for adding `calcite-tip`s.
  */
 @Component({
   tag: "calcite-tip-manager",
@@ -30,7 +30,7 @@ export class CalciteTipManager {
   //
   // --------------------------------------------------------------------------
   /**
-   * Alternate text for closing the Tip Manager.
+   * Alternate text for closing the tip manager.
    */
   @Prop({ reflect: true }) closed = false;
 
@@ -41,12 +41,12 @@ export class CalciteTipManager {
   }
 
   /**
-   * Alternate text for closing the Tip Manager.
+   * Alternate text for closing the tip manager.
    */
   @Prop() textClose = TEXT.close;
 
   /**
-   * The default group title for the Tip Manager.
+   * The default group title for the tip manager.
    */
   @Prop({ reflect: true }) textDefaultTitle = TEXT.defaultGroupTitle;
 
@@ -143,7 +143,7 @@ export class CalciteTipManager {
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted when the TipManager has been toggled closed or opened.
+   * Emitted when the tip manager has been toggled closed or opened.
    */
   @Event() calciteTipManagerToggle: EventEmitter;
 

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -30,7 +30,7 @@ export class CalciteTipManager {
   //
   // --------------------------------------------------------------------------
   /**
-   * Alternate text for closing the tip manager.
+   * Alternate text for closing the `calcite-tip-manager`.
    */
   @Prop({ reflect: true }) closed = false;
 
@@ -41,12 +41,12 @@ export class CalciteTipManager {
   }
 
   /**
-   * Alternate text for closing the tip manager.
+   * Alternate text for closing the `calcite-tip-manager`.
    */
   @Prop() textClose = TEXT.close;
 
   /**
-   * The default group title for the tip manager.
+   * The default group title for the `calcite-tip-manager`.
    */
   @Prop({ reflect: true }) textDefaultTitle = TEXT.defaultGroupTitle;
 
@@ -143,7 +143,7 @@ export class CalciteTipManager {
   // --------------------------------------------------------------------------
 
   /**
-   * Emitted when the tip manager has been toggled closed or opened.
+   * Emitted when the `calcite-tip-manager` has been toggled open or closed.
    */
   @Event() calciteTipManagerToggle: EventEmitter;
 

--- a/src/components/calcite-tip-manager/readme.md
+++ b/src/components/calcite-tip-manager/readme.md
@@ -1,8 +1,6 @@
 # calcite-tip-manager
 
-The `calcite-tip-manager` component contains multiple `calcite-tips` that a user can view through via interactive arrows to go back and forth through the tips in the deck.
-
-See the [calcite-tip-manager demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-tip-manager--basic).
+The `calcite-tip-manager` component contains multiple `calcite-tip`s that a user can view through via interactive arrows to go back and forth through the tips in the deck.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -35,7 +35,7 @@ export class CalciteTip {
   @Prop() heading: string;
 
   /**
-   * The selected state of the tip if it is being used inside a CalciteTipManager
+   * The selected state of the tip if it is being used inside a `calcite-tip-manager`.
    */
   @Prop({
     reflect: true

--- a/src/components/calcite-tip/readme.md
+++ b/src/components/calcite-tip/readme.md
@@ -2,8 +2,6 @@
 
 The `calcite-tip` component can comprise of an image, text and hyperlink to give helpful hints to a user about using the platform.
 
-See the [calcite-tip demo](https://esri.github.io/calcite-app-components/?path=/story/components-calcite-tip--basic).
-
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -5,7 +5,7 @@ import { CSS } from "../calcite-pick-list-item/resources";
 import { ICONS } from "./resources";
 
 /**
- * @slot secondaryAction - A slot intended for adding a calcite-action or calcite-button. Placed at the end of the item.
+ * @slot secondaryAction - A slot intended for adding a `calcite-action` or `calcite-button`. This is placed at the end of the item.
  */
 @Component({
   tag: "calcite-value-list-item",

--- a/src/components/calcite-value-list-item/readme.md
+++ b/src/components/calcite-value-list-item/readme.md
@@ -1,6 +1,6 @@
 # calcite-value-list-item
 
-`calcite-value-list-items` are cards contained in a `calcite-value-list`. They each can have a label and description, an icon and have their label's be editable (inherited from `calcite-value-list`). The developer can disable or preselect each list item and give it a value.
+`calcite-value-list-item`s are cards contained in a `calcite-value-list`. They each can have a label and description, an icon and can have their label's be editable (inherited from `calcite-value-list`). The developer can disable or preselect each list item and give it a value.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -48,7 +48,7 @@ describe("calcite-value-list", () => {
     disabledStates("value");
   });
 
-  describe.only("drag and drop", () => {
+  describe("drag and drop", () => {
     let page: E2EPage;
     beforeEach(async () => {
       page = await newE2EPage();

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -29,7 +29,7 @@ const {
 } = sharedListMethods;
 
 /**
- * @slot - A slot for adding pick-list-item elements or pick-list-groups elements. Items are displayed as a vertical list.
+ * @slot - A slot for adding `calcite-pick-list-item` elements or `calcite-pick-list-group` elements. Items are displayed as a vertical list.
  * @slot menu-actions - A slot for adding a button + menu combo for performing actions like sorting.
  */
 @Component({

--- a/src/components/calcite-value-list/readme.md
+++ b/src/components/calcite-value-list/readme.md
@@ -1,6 +1,6 @@
 # calcite-value-list
 
-`calcite-value-list` is housed in a panel and contains `calcite-value-list-items`. The value list has options for drag and drop, label editing, and single or multi select of items which can be done through shift+click.
+`calcite-value-list` is housed in a panel and contains `calcite-value-list-item`s. The value list has options for drag and drop, label editing, and single or multi select of items which can be done through shift+click.
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
**Related Issue:** #685 

took out irrelevant links that used to go back to our readme's.  Fixed some of `these thing`s and reworded a few things

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
