### PR TITLE
docs: calcite shell panel snippets

### DIFF
--- a/src/components/calcite-shell-panel/usage/basic.md
+++ b/src/components/calcite-shell-panel/usage/basic.md
@@ -1,0 +1,29 @@
+#### Basic
+
+Renders a basic shell panel with text content.
+
+```html
+<calcite-shell-panel>
+  <p>Primary Content</p>
+</calcite-shell-panel>
+```
+
+#### With action bar
+
+Renders a panel with an action bar.
+
+```html
+<calcite-shell-panel>
+  <calcite-action-bar slot="action-bar">
+    <calcite-action text="Add">
+      <calcite-icon scale="s" icon="plus"></calcite-icon>
+    </calcite-action>
+    <calcite-action text="Save">
+      <calcite-icon scale="s" icon="save"></calcite-icon>
+    </calcite-action>
+    <calcite-action text="Layers">
+      <calcite-icon scale="s" icon="layers"></calcite-icon>
+    </calcite-action>
+  </calcite-action-bar>
+</calcite-shell-panel>
+```

--- a/src/components/calcite-shell/usage/advanced.md
+++ b/src/components/calcite-shell/usage/advanced.md
@@ -51,29 +51,29 @@ note: calcite-icon is pulled in from [calcite-components](https://esri.github.io
       <calcite-action-bar slot="action-bar">
         <calcite-action-group>
           <calcite-action text="Add" active>
-            <calcite-icon scale="s" icon="plus">
+            <calcite-icon scale="s" icon="plus"></calcite-icon>
           </calcite-action>
           <calcite-action text="Save" disabled>
-            <calcite-icon scale="s" icon="save">
+            <calcite-icon scale="s" icon="save"></calcite-icon>
           </calcite-action>
           <calcite-action text="Layers">
-            <calcite-icon scale="s" icon="layers">
+            <calcite-icon scale="s" icon="layers"></calcite-icon>
           </calcite-action>
         </calcite-action-group>
         <calcite-action-group>
           <calcite-action text="Add">
-            <calcite-icon scale="s" icon="plus">
+            <calcite-icon scale="s" icon="plus"></calcite-icon>
           </calcite-action>
           <calcite-action text="Save" disabled>
-            <calcite-icon scale="s" icon="save">
+            <calcite-icon scale="s" icon="save"></calcite-icon>
           </calcite-action>
           <calcite-action text="Layers">
-            <calcite-icon scale="s" icon="layers">
+            <calcite-icon scale="s" icon="layers"></calcite-icon>
           </calcite-action>
         </calcite-action-group>
         <calcite-action-group slot="bottom-actions">
           <calcite-action text="Tips">
-            <calcite-icon scale="s" icon="lightbulb">
+            <calcite-icon scale="s" icon="lightbulb"></calcite-icon>
           </calcite-action>
         </calcite-action-group>
       </calcite-action-bar>
@@ -83,17 +83,17 @@ note: calcite-icon is pulled in from [calcite-components](https://esri.github.io
             <calcite-value-list multiple filter-enabled>
               <calcite-value-list-item text-label="2018 Population Density (Esri)" text-description="{POPDENS_CY}" value="POPDENS_CY">
                 <calcite-action slot="secondaryAction">
-                  <calcite-icon scale="s" icon="camera-flash-on">
+                  <calcite-icon scale="s" icon="camera-flash-on"></calcite-icon>
                 </calcite-action>
               </calcite-value-list-item>
               <calcite-value-list-item text-label="2018 Population Density [Updated]" text-description="{POPDENS_CY}" value="POPDENS_CY2">
                 <calcite-action slot="secondaryAction">
-                  <calcite-icon scale="s" icon="banana">
+                  <calcite-icon scale="s" icon="banana"></calcite-icon>
                 </calcite-action>
               </calcite-value-list-item>
               <calcite-value-list-item text-label="2018 Total Households (Esri)" text-description="{TOTHH_CY}" value="TOTHH_CY">
                 <calcite-action slot="secondaryAction">
-                  <calcite-icon scale="s" icon="person2">
+                  <calcite-icon scale="s" icon="person2"></calcite-icon>
                 </calcite-action>
               </calcite-value-list-item>
             </calcite-value-list>

--- a/src/components/calcite-shell/usage/basic.md
+++ b/src/components/calcite-shell/usage/basic.md
@@ -46,14 +46,14 @@ Renders a single panel with actions in an action bar.
   <calcite-shell-panel slot="primary-panel" layout="leading">
     <img src="https://via.placeholder.com/300x200" alt="placeholder" />
     <calcite-action-bar slot="action-bar">
-      <calcite-action text="Add">
-        <calcite-icon>
+      <calcite-action text="Add" active>
+        <calcite-icon scale="s" icon="plus"></calcite-icon>
       </calcite-action>
-      <calcite-action text="Save">
-        <calcite-icon>
+      <calcite-action text="Save" disabled>
+        <calcite-icon scale="s" icon="save"></calcite-icon>
       </calcite-action>
       <calcite-action text="Layers">
-        <calcite-icon>
+        <calcite-icon scale="s" icon="layers"></calcite-icon>
       </calcite-action>
     </calcite-action-bar>
   </calcite-shell-panel>


### PR DESCRIPTION
**Related Issue:** #619 #702 
Fixed the closing calcite-icon for shell snippets as well. Shell snippets were just merged, so hope it's ok to do it here

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
