### PR TITLE
fix: prevent window scrolling when using arrow keys in flow-item menu

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -137,6 +137,8 @@ export class CalciteFlowItem {
       return;
     }
 
+    event.preventDefault();
+
     if (!menuOpen) {
       this.menuOpen = true;
     }
@@ -166,6 +168,8 @@ export class CalciteFlowItem {
     if (!length || currentIndex === -1) {
       return;
     }
+
+    event.preventDefault();
 
     if (key === "ArrowUp") {
       const value = getRoundRobinIndex(currentIndex - 1, length);


### PR DESCRIPTION
**Related Issue:** None

## Summary

fix: prevent window scrolling when using arrow keys in flow-item menu