### PR TITLE
docs: calcite value list snippets

### DIFF
--- a/src/components/calcite-value-list/usage/basic.md
+++ b/src/components/calcite-value-list/usage/basic.md
@@ -3,19 +3,68 @@
 Renders a value list with multiple items able to be selected and a filter.
 
 ```html
-<calcite-value-list id="one" multiple="true" filter-enabled>
+<calcite-value-list multiple="true" filter-enabled>
   <calcite-value-list-item text-label="Dogs" text-description="Man's best friend" value="dogs">
-    <calcite-action slot="secondaryAction"></calcite-action>
+    <calcite-action slot="secondaryAction">
+      <calcite-icon scale="s" icon="plus"></calcite-icon>
+    </calcite-action>
   </calcite-value-list-item>
   <calcite-value-list-item text-label="Cats" text-description="Independent and fluffy" value="cats">
-    <calcite-action slot="secondaryAction"></calcite-action>
+    <calcite-action slot="secondaryAction">
+      <calcite-icon scale="s" icon="plus"></calcite-icon>
+    </calcite-action>
   </calcite-value-list-item>
   <calcite-value-list-item
     text-label="Fish. But not just any fish, a tiger fish caught live in the Atlantic Ocean while on vacation."
     text-description="Easy to care for."
     value="fish"
   >
-    <calcite-action slot="secondaryAction"></calcite-action>
+    <calcite-action slot="secondaryAction">
+      <calcite-icon scale="s" icon="plus"></calcite-icon>
+    </calcite-action>
+  </calcite-value-list-item>
+</calcite-value-list>
+```
+
+#### Drag and drop
+
+Renders a compact value list (no text descriptions) with drag and drop capability between the items.
+
+```html
+<calcite-value-list drag-enabled compact>
+  <calcite-value-list-item text-label="Rent" text-description="Mortgage + housing costs" value="rent">
+  </calcite-value-list-item>
+  <calcite-value-list-item text-label="Food" text-description="its what you eat." value="food">
+  </calcite-value-list-item>
+  <calcite-value-list-item text-label="Utilities" value="utilities"> </calcite-value-list-item>
+  <calcite-value-list-item text-label="Entertainment" text-description="Toys and leisure" value="entertainment">
+  </calcite-value-list-item>
+</calcite-value-list>
+```
+
+#### Label editing and single select
+
+Renders a value list with label editing and single select.
+
+```html
+<calcite-value-list label-editing-enabled="true">
+  <calcite-value-list-item
+    text-label="2018 Generation Alpha Population (Born 2017 or Later) [updated 2019-09-18]"
+    text-description="GENALPHACY"
+    value="GENALPHACY"
+  >
+  </calcite-value-list-item>
+  <calcite-value-list-item
+    text-label="2010-2018 Households: Annual Growth Rate (Esri)"
+    text-description="HHGRW10CY-2019-09-18.001ZZYLKJ"
+    value="HHGRW10CY"
+  >
+  </calcite-value-list-item>
+  <calcite-value-list-item
+    text-label="2010-2018 Households: Annual Growth Rate (Esri)"
+    text-description="HHGRW10CY-2019-09-18.001ZZYYZLKJ"
+    value="HHGRW10CY2"
+  >
   </calcite-value-list-item>
 </calcite-value-list>
 ```

--- a/src/components/calcite-value-list/usage/basic.md
+++ b/src/components/calcite-value-list/usage/basic.md
@@ -1,0 +1,21 @@
+#### Basic
+
+Renders a value list with multiple items able to be selected and a filter.
+
+```html
+<calcite-value-list id="one" multiple="true" filter-enabled>
+  <calcite-value-list-item text-label="Dogs" text-description="Man's best friend" value="dogs">
+    <calcite-action slot="secondaryAction"></calcite-action>
+  </calcite-value-list-item>
+  <calcite-value-list-item text-label="Cats" text-description="Independent and fluffy" value="cats">
+    <calcite-action slot="secondaryAction"></calcite-action>
+  </calcite-value-list-item>
+  <calcite-value-list-item
+    text-label="Fish. But not just any fish, a tiger fish caught live in the Atlantic Ocean while on vacation."
+    text-description="Easy to care for."
+    value="fish"
+  >
+    <calcite-action slot="secondaryAction"></calcite-action>
+  </calcite-value-list-item>
+</calcite-value-list>
+```

--- a/src/demos/shell/basic.html
+++ b/src/demos/shell/basic.html
@@ -42,113 +42,46 @@
         <h2>Basic Shell</h2>
         <div class="shell-container">
           <calcite-shell>
-            <calcite-shell-panel slot="primary-panel" layout="leading" detached>
-              <calcite-action-pad placement="side" slot="action-pad" hidden>
-                <calcite-action-group>
-                  <calcite-action text="Add">
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-action-group>
-              </calcite-action-pad>
-              <calcite-action-bar slot="action-bar" theme="dark">
-                <calcite-action-group>
-                  <calcite-action text="Add">
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Save" disabled>
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Layers" active indicator>
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-action-group>
-                <calcite-action-group>
-                  <calcite-action text="Add">
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Layers" indicator>
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-action-group>
-              </calcite-action-bar>
-              <calcite-block collapsible  heading="Primary Content" summary="This is the primary.">
-                <calcite-block-content>
-                  <calcite-action text="Puppies" text-enabled indicator>
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Kittens" text-enabled>
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Birds?" text-enabled>
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-block-content>
-              </calcite-block>
-              <calcite-block collapsible  heading="Additional Block" summary="Baby shark doo doo doo doo.">
-                <calcite-block-content>
-                    <p>Cool thing.</p>
-                </calcite-block-content>
-              </calcite-block>
+            <div slot="shell-header">
+              <header class="header">
+                <h2 class="heading">Shell Header: My App</h2>
+              </header>
+            </div>
+            <p>Shell Content</p>
+            <img src="https://via.placeholder.com/700x400" alt="placeholder" />
+          </calcite-shell>
+        </div>
+        <h2>Shell with Footer</h2>
+        <div class="shell-container">
+          <calcite-shell>
+            <div slot="shell-header">
+              <header class="header">
+                <h2 class="heading">Shell Header: My App</h2>
+              </header>
+            </div>
+            <p>Shell Content</p>
+            <img src="https://via.placeholder.com/700x400" alt="placeholder" />
+
+            <footer slot="shell-footer">Footer</footer>
+          </calcite-shell>
+        </div>
+        <h2>Shell with Panels</h2>
+        <div class="shell-container">
+          <calcite-shell>
+            <calcite-shell-panel slot="primary-panel" layout="leading">
+              leading panel
             </calcite-shell-panel>
 
-             <calcite-shell-panel slot="contextual-panel" layout="trailing" detached detached-scale="l">
-                <calcite-action-bar slot="action-bar">
-                  <calcite-action-group>
-                    <calcite-action text="Add" active>
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Save" disabled>
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Layers">
-                      <calcite-icon>
-                    </calcite-action>
-                  </calcite-action-group>
-                  <calcite-action-group>
-                    <calcite-action text="Add">
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Save" disabled>
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Layers">
-                      <calcite-icon>
-                    </calcite-action>
-                  </calcite-action-group>
-                  <calcite-action-group slot="bottom-actions">
-                    <calcite-action text="Tips">
-                      <calcite-icon>
-                    </calcite-action>
-                  </calcite-action-group>
-                </calcite-action-bar>
-                <calcite-flow>
-                  <calcite-flow-item heading="Layer settings">
-                    <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
-                      <calcite-value-list multiple filter-enabled>
-                        <calcite-value-list-item text-label="2018 Population Density (Esri)" text-description="{POPDENS_CY}" value="POPDENS_CY">
-                          <calcite-action slot="secondaryAction">
-                            <calcite-icon>
-                          </calcite-action>
-                        </calcite-value-list-item>
-                        <calcite-value-list-item text-label="2018 Population Density [Updated]" text-description="{POPDENS_CY}" value="POPDENS_CY2">
-                          <calcite-action slot="secondaryAction">
-                            <calcite-icon>
-                          </calcite-action>
-                        </calcite-value-list-item>
-                        <calcite-value-list-item text-label="2018 Total Households (Esri)" text-description="{TOTHH_CY}" value="TOTHH_CY">
-                          <calcite-action slot="secondaryAction">
-                          </calcite-action>
-                        </calcite-value-list-item>
-                      </calcite-value-list>
-                    </calcite-block>
-                  </calcite-flow-item>
-                </calcite-flow>
+            <calcite-shell-panel slot="contextual-panel" layout="trailing">
+              trailing panel
             </calcite-shell-panel>
-            <calcite-tip-manager slot="tip-manager">
-              <calcite-tip heading="The Red Rocks and Blue Water" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of nature.">
-              <calcite-tip heading="The Long Trees" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of trees.">
-            </calcite-tip-manager>
-            <footer slot="shell-footer">Footer</footer>
+            <div slot="shell-header">
+              <header class="header">
+                <h2 class="heading">Shell Header: My App</h2>
+              </header>
+            </div>
+            <p>Shell Content</p>
+            <img src="https://via.placeholder.com/700x400" alt="placeholder" />
           </calcite-shell>
         </div>
 


### PR DESCRIPTION
**Related Issue:** #619 #704 

## Summary
I still have the slot as 'secondaryAction'. Let me know if you'd like to change this now or later?

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
