### PR TITLE
docs: snippet cleanup

### DIFF
--- a/src/components/calcite-action-bar/usage/basic.md
+++ b/src/components/calcite-action-bar/usage/basic.md
@@ -5,10 +5,10 @@ Renders `calcite-action`s that stick to the top of the bar.
 ```html
 <calcite-action-bar>
   <calcite-action text="Add">
-    <!-- icon -->
+    <calcite-icon scale="s" icon="plus"></calcite-icon>
   </calcite-action>
   <calcite-action text="Save">
-    <!-- icon -->
+    <calcite-icon scale="s" icon="save"></calcite-icon>
   </calcite-action>
 </calcite-action-bar>
 ```
@@ -21,19 +21,19 @@ Renders a group of `calcite-action`s contained in a `calcite-action-group`. Acti
 <calcite-action-bar>
   <calcite-action-group>
     <calcite-action text="Add">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="plus"></calcite-icon>
     </calcite-action>
     <calcite-action text="Save">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="save"></calcite-icon>
     </calcite-action>
   </calcite-action-group>
 
   <calcite-action-group>
     <calcite-action text="Layers">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="layers"></calcite-icon>
     </calcite-action>
     <calcite-action text="Basemaps">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="layer-basemap"></calcite-icon>
     </calcite-action>
   </calcite-action-group>
 </calcite-action-bar>
@@ -46,12 +46,12 @@ The bottom-actions slot renders `calcite-action`s that stick to the bottom of th
 ```html
 <calcite-action-bar>
   <calcite-action text="Information">
-    <!-- icon -->
+    <calcite-icon scale="s" icon="information"></calcite-icon>
   </calcite-action>
 
   <div slot="bottom-actions">
     <calcite-action text="Feedback">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="mega-phone"></calcite-icon>
     </calcite-action>
   </div>
 </calcite-action-bar>

--- a/src/components/calcite-action-pad/usage/basic.md
+++ b/src/components/calcite-action-pad/usage/basic.md
@@ -5,10 +5,10 @@ Renders a basic action pad with `calcite-action`s.
 ```html
 <calcite-action-pad>
   <calcite-action text="Undo">
-    <!-- icon -->
+    <calcite-icon scale="s" icon="undo"></calcite-icon>
   </calcite-action>
   <calcite-action text="Redo">
-    <!-- icon -->
+    <calcite-icon scale="s" icon="redo"></calcite-icon>
   </calcite-action>
 </calcite-action-pad>
 ```
@@ -21,15 +21,15 @@ Renders a group of `calcite-action`s contained in a `calcite-action-group`. Acti
 <calcite-action-pad>
   <calcite-action-group>
     <calcite-action text="Home">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="home"></calcite-icon>
     </calcite-action>
     <calcite-action text="Styles">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="add-in-edit"></calcite-icon>
     </calcite-action>
   </calcite-action-group>
 
   <calcite-action text="Tips">
-    <!-- icon -->
+    <calcite-icon scale="s" icon="lightbulb"></calcite-icon>
   </calcite-action>
 </calcite-action-pad>
 ```

--- a/src/components/calcite-action/usage/basic.md
+++ b/src/components/calcite-action/usage/basic.md
@@ -4,7 +4,7 @@ Renders a `calcite-action` that displays only an icon and a tooltip label.
 
 ```html
 <calcite-action label="Performs my custom action">
-  <!-- icon -->
+  <calcite-icon scale="s" icon="plus"></calcite-icon>
 </calcite-action>
 ```
 
@@ -14,7 +14,7 @@ Renders a `calcite-action` that displays text along side an icon and a tooltip l
 
 ```html
 <calcite-action label="Performs my custom action" text="Perform Action!" text-enabled>
-  <!-- icon -->
+  <calcite-icon scale="s" icon="save"></calcite-icon>
 </calcite-action>
 ```
 
@@ -24,6 +24,6 @@ Renders a `calcite-action` that has a clear background.
 
 ```html
 <calcite-action appearance="clear">
-  <!-- icon -->
+  <calcite-icon scale="s" icon="layers"></calcite-icon>
 </calcite-action>
 ```

--- a/src/components/calcite-panel/usage/basic.md
+++ b/src/components/calcite-panel/usage/basic.md
@@ -29,13 +29,13 @@ Renders a panel with leading and trailing `calcite-action`s.
 <calcite-panel>
   <div slot="header-leading-content">
     <calcite-action label="Performs my custom action" text="Perform Action!" text-enabled>
-      <!-- icon -->
+      <calcite-icon scale="s" icon="home"></calcite-icon>
     </calcite-action>
   </div>
   <div slot="header-content">Header!</div>
   <div slot="header-trailing-content">
     <calcite-action label="Performs another custom action" text="Perform Another Action!" text-enabled>
-      <!-- icon -->
+      <calcite-icon scale="s" icon="blog"></calcite-icon>
     </calcite-action>
   </div>
   <p>Actions are in the top left and right.</p>

--- a/src/components/calcite-pick-list/usage/basic.md
+++ b/src/components/calcite-pick-list/usage/basic.md
@@ -6,17 +6,17 @@ Renders a basic pick list with radio buttons and actions on the right side.
 <calcite-pick-list>
   <calcite-pick-list-item text-label="T. Rex" text-description="Arm strength impaired" value="trex">
     <calcite-action slot="secondaryAction">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="circle"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
   <calcite-pick-list-item text-label="Triceratops" text-description="3 horn" value="triceratops" selected>
     <calcite-action slot="secondaryAction">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="circle"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
   <calcite-pick-list-item text-label="Velociraptor" text-description="Swift seizer" value="velociraptor">
     <calcite-action slot="secondaryAction">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="circle"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
 </calcite-pick-list>
@@ -30,17 +30,17 @@ Renders a pick list with a sticky filter and checkboxes for multiple selection o
 <calcite-pick-list multiple filter-enabled>
   <calcite-pick-list-item text-label="Chocolate" value="chocolate">
     <calcite-action slot="secondaryAction">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="ellipsis-circle"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
   <calcite-pick-list-item text-label="Vanilla" text-description="Oldie but goodie" value="vanilla">
     <calcite-action slot="secondaryAction">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="ellipsis-circle"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
   <calcite-pick-list-item text-label="Strawberry" text-description="no metadata on this one" value="strawberry">
     <calcite-action slot="secondaryAction">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="ellipsis-circle"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
 </calcite-pick-list>
@@ -55,24 +55,24 @@ Renders groups of pick list items that are visually separated.
   <calcite-pick-list-group text-group-title="numbers">
     <calcite-pick-list-item text-heading="one" text-description="fish" value="one" icon="grip">
       <calcite-action slot="secondaryAction">
-        <!-- icon -->
+        <calcite-icon scale="s" icon="ellipsis"></calcite-icon>
       </calcite-action>
     </calcite-pick-list-item>
     <calcite-pick-list-item text-heading="two" text-description="fish" value="two" icon="grip">
       <calcite-action slot="secondaryAction">
-        <!-- icon -->
+        <calcite-icon scale="s" icon="ellipsis"></calcite-icon>
       </calcite-action>
     </calcite-pick-list-item>
   </calcite-pick-list-group>
   <calcite-pick-list-group text-group-title="colors">
     <calcite-pick-list-item text-heading="red" text-description="fish" value="red" icon="grip">
       <calcite-action slot="secondaryAction">
-        <!-- icon -->
+        <calcite-icon scale="s" icon="ellipsis"></calcite-icon>
       </calcite-action>
     </calcite-pick-list-item>
     <calcite-pick-list-item text-heading="blue" text-description="fish" value="blue" icon="grip">
       <calcite-action slot="secondaryAction">
-        <!-- icon -->
+        <calcite-icon scale="s" icon="ellipsis"></calcite-icon>
       </calcite-action>
     </calcite-pick-list-item>
   </calcite-pick-list-group>
@@ -91,12 +91,12 @@ Renders compact list items with the text description and a bit of padding remove
     value="ID"
   >
     <calcite-action slot="secondaryAction" id="action-test">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="banana"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
   <calcite-pick-list-item text-label="OBJECTID" value="OBJECTID">
     <calcite-action slot="secondaryAction" id="action-test">
-      <!-- icon -->
+      <calcite-icon scale="s" icon="banana"></calcite-icon>
     </calcite-action>
   </calcite-pick-list-item>
 </calcite-pick-list>

--- a/src/demos/shell/basic.html
+++ b/src/demos/shell/basic.html
@@ -42,113 +42,46 @@
         <h2>Basic Shell</h2>
         <div class="shell-container">
           <calcite-shell>
-            <calcite-shell-panel slot="primary-panel" layout="leading" detached>
-              <calcite-action-pad placement="side" slot="action-pad" hidden>
-                <calcite-action-group>
-                  <calcite-action text="Add">
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-action-group>
-              </calcite-action-pad>
-              <calcite-action-bar slot="action-bar" theme="dark">
-                <calcite-action-group>
-                  <calcite-action text="Add">
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Save" disabled>
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Layers" active indicator>
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-action-group>
-                <calcite-action-group>
-                  <calcite-action text="Add">
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Layers" indicator>
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-action-group>
-              </calcite-action-bar>
-              <calcite-block collapsible  heading="Primary Content" summary="This is the primary.">
-                <calcite-block-content>
-                  <calcite-action text="Puppies" text-enabled indicator>
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Kittens" text-enabled>
-                    <calcite-icon>
-                  </calcite-action>
-                  <calcite-action text="Birds?" text-enabled>
-                    <calcite-icon>
-                  </calcite-action>
-                </calcite-block-content>
-              </calcite-block>
-              <calcite-block collapsible  heading="Additional Block" summary="Baby shark doo doo doo doo.">
-                <calcite-block-content>
-                    <p>Cool thing.</p>
-                </calcite-block-content>
-              </calcite-block>
+            <div slot="shell-header">
+              <header class="header">
+                <h2 class="heading">Shell Header: My App</h2>
+              </header>
+            </div>
+            <p>Shell Content</p>
+            <img src="https://via.placeholder.com/700x400" alt="placeholder" />
+          </calcite-shell>
+        </div>
+        <h2>Shell with Footer</h2>
+        <div class="shell-container">
+          <calcite-shell>
+            <div slot="shell-header">
+              <header class="header">
+                <h2 class="heading">Shell Header: My App</h2>
+              </header>
+            </div>
+            <p>Shell Content</p>
+            <img src="https://via.placeholder.com/700x400" alt="placeholder" />
+
+            <footer slot="shell-footer">Footer</footer>
+          </calcite-shell>
+        </div>
+        <h2>Shell with Panels</h2>
+        <div class="shell-container">
+          <calcite-shell>
+            <calcite-shell-panel slot="primary-panel" layout="leading">
+              leading panel
             </calcite-shell-panel>
 
-             <calcite-shell-panel slot="contextual-panel" layout="trailing" detached detached-scale="l">
-                <calcite-action-bar slot="action-bar">
-                  <calcite-action-group>
-                    <calcite-action text="Add" active>
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Save" disabled>
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Layers">
-                      <calcite-icon>
-                    </calcite-action>
-                  </calcite-action-group>
-                  <calcite-action-group>
-                    <calcite-action text="Add">
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Save" disabled>
-                      <calcite-icon>
-                    </calcite-action>
-                    <calcite-action text="Layers">
-                      <calcite-icon>
-                    </calcite-action>
-                  </calcite-action-group>
-                  <calcite-action-group slot="bottom-actions">
-                    <calcite-action text="Tips">
-                      <calcite-icon>
-                    </calcite-action>
-                  </calcite-action-group>
-                </calcite-action-bar>
-                <calcite-flow>
-                  <calcite-flow-item heading="Layer settings">
-                    <calcite-block collapsible open heading="Contextual Content" summary="Select goodness">
-                      <calcite-value-list multiple filter-enabled>
-                        <calcite-value-list-item text-label="2018 Population Density (Esri)" text-description="{POPDENS_CY}" value="POPDENS_CY">
-                          <calcite-action slot="secondaryAction">
-                            <calcite-icon>
-                          </calcite-action>
-                        </calcite-value-list-item>
-                        <calcite-value-list-item text-label="2018 Population Density [Updated]" text-description="{POPDENS_CY}" value="POPDENS_CY2">
-                          <calcite-action slot="secondaryAction">
-                            <calcite-icon>
-                          </calcite-action>
-                        </calcite-value-list-item>
-                        <calcite-value-list-item text-label="2018 Total Households (Esri)" text-description="{TOTHH_CY}" value="TOTHH_CY">
-                          <calcite-action slot="secondaryAction">
-                          </calcite-action>
-                        </calcite-value-list-item>
-                      </calcite-value-list>
-                    </calcite-block>
-                  </calcite-flow-item>
-                </calcite-flow>
+            <calcite-shell-panel slot="contextual-panel" layout="trailing">
+              trailing panel
             </calcite-shell-panel>
-            <calcite-tip-manager slot="tip-manager">
-              <calcite-tip heading="The Red Rocks and Blue Water" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of nature.">
-              <calcite-tip heading="The Long Trees" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of trees.">
-            </calcite-tip-manager>
-            <footer slot="shell-footer">Footer</footer>
+            <div slot="shell-header">
+              <header class="header">
+                <h2 class="heading">Shell Header: My App</h2>
+              </header>
+            </div>
+            <p>Shell Content</p>
+            <img src="https://via.placeholder.com/700x400" alt="placeholder" />
           </calcite-shell>
         </div>
 


### PR DESCRIPTION
**Related Issue:** #619 

## Summary
Added <calcite-icon>s to the example snippets

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
