### PR TITLE
fix: FlowItem RTL trailing icon isn't on the far side #721

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -5,6 +5,7 @@ import classnames from "classnames";
 import { BLACKLISTED_MENU_ACTIONS_COMPONENTS, CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { getRoundRobinIndex } from "../utils/array";
 import { CalciteScale, CalciteTheme } from "../interfaces";
+import { CSS_UTILITY } from "../utils/resources";
 
 const SUPPORTED_ARROW_KEYS = ["ArrowUp", "ArrowDown"];
 
@@ -292,7 +293,9 @@ export class CalciteFlowItem {
         : null;
 
     return menuActionsNodes ? (
-      <div slot={SLOTS.headerTrailingContent}>{menuActionsNodes}</div>
+      <div slot={SLOTS.headerTrailingContent} class={CSS.headerActions}>
+        {menuActionsNodes}
+      </div>
     ) : null;
   }
 
@@ -317,6 +320,9 @@ export class CalciteFlowItem {
           loading={this.loading}
           disabled={this.disabled}
           height-scale={this.heightScale}
+          class={classnames({
+            [CSS_UTILITY.rtl]: rtl
+          })}
         >
           {this.renderBackButton(rtl)}
           {this.renderHeading()}

--- a/src/components/calcite-flow-item/resources.ts
+++ b/src/components/calcite-flow-item/resources.ts
@@ -4,6 +4,7 @@ export const CSS = {
   heading: "heading",
   backButton: "back-button",
   footerActions: "footer-actions",
+  headerActions: "header-actions",
   singleActionContainer: "single-action-container",
   menuContainer: "menu-container",
   menuButton: "menu-button",

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -75,7 +75,6 @@ slot[name="header-content"]::slotted(.heading) {
 
 .header-trailing-content {
   display: flex;
-  margin-left: auto;
   margin-bottom: var(--calcite-app-cap-spacing-minimum);
 }
 


### PR DESCRIPTION
**Related Issue:** FlowItem RTL trailing icon isn't on the far side #721

## Summary

FlowItem RTL trailing icon isn't on the far side #721
