### PR TITLE
fix: addresses safari bugs with pick-list and value-list

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -1,5 +1,6 @@
 :host {
   display: flex;
+  flex: 1 0 auto;
   flex-direction: column;
   border-radius: var(--calcite-app-border-radius);
   margin: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-quarter) 0;

--- a/src/components/calcite-pick-list/calcite-pick-list.scss
+++ b/src/components/calcite-pick-list/calcite-pick-list.scss
@@ -2,6 +2,7 @@
   align-items: stretch;
   background-color: var(--calcite-app-background-clear);
   display: flex;
+  flex: 1 0 auto;
   flex-flow: column;
   padding-bottom: var(--calcite-app-cap-spacing-half);
   position: relative;

--- a/src/components/calcite-value-list/calcite-value-list.scss
+++ b/src/components/calcite-value-list/calcite-value-list.scss
@@ -2,6 +2,7 @@
   align-items: stretch;
   background-color: var(--calcite-app-background-clear);
   display: flex;
+  flex: 0 0 auto;
   flex-flow: column;
   position: relative;
 }


### PR DESCRIPTION
**Related Issue:** #565 
Might also fix #555 

## Summary
Some minor updates that should complete fixes for Safari and retain good layout in Chrome.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

@AdelheidF Checked this in map viewer beta. Requires removing height rules from pick-list and adding `height-scale="m" to panel`

![image](https://user-images.githubusercontent.com/12503298/71694303-97cc9200-2d63-11ea-9fd2-af259e4b8443.png)

