### PR TITLE
chore: change config so readme only built on prod build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "stencil build",
+    "build": "stencil build --docs",
     "build:docs": "stencil build --config stencil.storybook.config.ts",
     "demoPageSync": "ts-node ./support/demoPageSync.ts",
     "deps:update": "updtr --ex @types/jest @types/puppeteer jest jest-cli puppeteer && git add package*.json && git commit -q -m \"chore(deps): Bump versions.\"",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -26,7 +26,6 @@ export const create: () => Config = () => ({
   ],
   outputTargets: [
     { type: "dist" },
-    { type: "docs-readme" },
     {
       type: "www",
       copy: [


### PR DESCRIPTION
## Summary

* `npm run test` and `npm run start` will no longer generated readme files for components.
* `npm run build` will still generated readme files.
