### PR TITLE
fix: only modify textEnabled when expand functionality is enabled

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -89,6 +89,30 @@ describe("calcite-action-bar", () => {
 
       expect(textEnabled).toBe(true);
     });
+
+    it("should not have bottomGroup when expand is false", async () => {
+      const page = await newE2EPage();
+
+      await page.setContent(`<calcite-action-bar expand="false"></calcite-action-bar>`);
+
+      const buttonGroup = await page.find(`calcite-action-bar >>> .${CSS.actionGroupBottom}`);
+
+      expect(buttonGroup).toBeNull();
+    });
+
+    it("should not modify textEnabled on actions when expand is false", async () => {
+      const page = await newE2EPage();
+
+      await page.setContent(
+        `<calcite-action-bar expand="false" expanded><calcite-action text="hello"></calcite-action></calcite-action-bar>`
+      );
+
+      const action = await page.find("calcite-action");
+
+      const textEnabled = await action.getProperty("textEnabled");
+
+      expect(textEnabled).toBe(false);
+    });
   });
 
   it("should be accessible", async () =>

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -28,7 +28,9 @@ export class CalciteActionBar {
 
   @Watch("expand")
   expandHandler(expand: boolean) {
-    toggleChildActionText({ parent: this.el, expand, expanded: this.expanded });
+    if (expand) {
+      toggleChildActionText({ parent: this.el, expanded: this.expanded });
+    }
   }
 
   /**
@@ -38,7 +40,9 @@ export class CalciteActionBar {
 
   @Watch("expanded")
   expandedHandler(expanded: boolean) {
-    toggleChildActionText({ parent: this.el, expand: this.expand, expanded });
+    if (this.expand) {
+      toggleChildActionText({ parent: this.el, expanded });
+    }
 
     this.calciteActionBarToggle.emit();
   }
@@ -92,7 +96,10 @@ export class CalciteActionBar {
 
   componentWillLoad() {
     const { el, expand, expanded } = this;
-    toggleChildActionText({ parent: el, expand, expanded });
+
+    if (expand) {
+      toggleChildActionText({ parent: el, expanded });
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -26,6 +26,11 @@ export class CalciteActionBar {
    */
   @Prop({ reflect: true }) expand = true;
 
+  @Watch("expand")
+  expandHandler(expand: boolean) {
+    toggleChildActionText({ parent: this.el, expand, expanded: this.expanded });
+  }
+
   /**
    * Indicates whether widget is expanded.
    */
@@ -33,7 +38,7 @@ export class CalciteActionBar {
 
   @Watch("expanded")
   expandedHandler(expanded: boolean) {
-    toggleChildActionText({ parent: this.el, expanded });
+    toggleChildActionText({ parent: this.el, expand: this.expand, expanded });
 
     this.calciteActionBarToggle.emit();
   }
@@ -86,8 +91,8 @@ export class CalciteActionBar {
   // --------------------------------------------------------------------------
 
   componentWillLoad() {
-    const { el, expanded } = this;
-    toggleChildActionText({ parent: el, expanded });
+    const { el, expand, expanded } = this;
+    toggleChildActionText({ parent: el, expand, expanded });
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.e2e.ts
@@ -91,6 +91,30 @@ describe("calcite-action-pad", () => {
     });
   });
 
+  it("should not have bottomGroup when expand is false", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-action-bar expand="false"></calcite-action-bar>`);
+
+    const buttonGroup = await page.find(`calcite-action-bar >>> .${CSS.actionGroupBottom}`);
+
+    expect(buttonGroup).toBeNull();
+  });
+
+  it("should not modify textEnabled on actions when expand is false", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      `<calcite-action-bar expand="false" expanded><calcite-action text="hello"></calcite-action></calcite-action-bar>`
+    );
+
+    const action = await page.find("calcite-action");
+
+    const textEnabled = await action.getProperty("textEnabled");
+
+    expect(textEnabled).toBe(false);
+  });
+
   it("should be accessible", async () =>
     accessible(`
     <calcite-action-pad>

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -25,6 +25,11 @@ export class CalciteActionPad {
    */
   @Prop({ reflect: true }) expand = true;
 
+  @Watch("expand")
+  expandHandler(expand: boolean) {
+    toggleChildActionText({ parent: this.el, expand, expanded: this.expanded });
+  }
+
   /**
    * Indicates whether widget is expanded.
    */
@@ -32,7 +37,7 @@ export class CalciteActionPad {
 
   @Watch("expanded")
   expandedHandler(expanded: boolean) {
-    toggleChildActionText({ parent: this.el, expanded });
+    toggleChildActionText({ parent: this.el, expand: this.expand, expanded });
 
     this.calciteActionPadToggle.emit();
   }
@@ -83,8 +88,8 @@ export class CalciteActionPad {
   // --------------------------------------------------------------------------
 
   componentWillLoad() {
-    const { el, expanded } = this;
-    toggleChildActionText({ parent: el, expanded });
+    const { el, expand, expanded } = this;
+    toggleChildActionText({ parent: el, expand, expanded });
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -27,7 +27,9 @@ export class CalciteActionPad {
 
   @Watch("expand")
   expandHandler(expand: boolean) {
-    toggleChildActionText({ parent: this.el, expand, expanded: this.expanded });
+    if (expand) {
+      toggleChildActionText({ parent: this.el, expanded: this.expanded });
+    }
   }
 
   /**
@@ -37,7 +39,9 @@ export class CalciteActionPad {
 
   @Watch("expanded")
   expandedHandler(expanded: boolean) {
-    toggleChildActionText({ parent: this.el, expand: this.expand, expanded });
+    if (this.expand) {
+      toggleChildActionText({ parent: this.el, expanded });
+    }
 
     this.calciteActionPadToggle.emit();
   }
@@ -89,7 +93,10 @@ export class CalciteActionPad {
 
   componentWillLoad() {
     const { el, expand, expanded } = this;
-    toggleChildActionText({ parent: el, expand, expanded });
+
+    if (expand) {
+      toggleChildActionText({ parent: el, expanded });
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/utils/CalciteExpandToggle.tsx
+++ b/src/components/utils/CalciteExpandToggle.tsx
@@ -28,15 +28,12 @@ function getClosestShellLayout(el: HTMLElement): CalciteLayout | null {
 
 export function toggleChildActionText({
   parent,
-  expand,
   expanded
 }: {
   parent: HTMLElement;
-  expand: boolean;
   expanded: boolean;
 }): void {
-  expand &&
-    parent.querySelectorAll("calcite-action").forEach((action) => (action.textEnabled = expanded));
+  parent.querySelectorAll("calcite-action").forEach((action) => (action.textEnabled = expanded));
 }
 
 export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> = ({

--- a/src/components/utils/CalciteExpandToggle.tsx
+++ b/src/components/utils/CalciteExpandToggle.tsx
@@ -28,12 +28,15 @@ function getClosestShellLayout(el: HTMLElement): CalciteLayout | null {
 
 export function toggleChildActionText({
   parent,
+  expand,
   expanded
 }: {
   parent: HTMLElement;
+  expand: boolean;
   expanded: boolean;
 }): void {
-  parent.querySelectorAll("calcite-action").forEach((action) => (action.textEnabled = expanded));
+  expand &&
+    parent.querySelectorAll("calcite-action").forEach((action) => (action.textEnabled = expanded));
 }
 
 export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> = ({


### PR DESCRIPTION
**Related Issue:** None

## Summary

fix: only modify textEnabled when expand functionality is enabled