### PR TITLE
chore: cleanup rendering of the header in flow item

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -322,14 +322,13 @@ export class CalciteFlowItem {
 
   renderHeader(): VNode {
     const headingNode = this.renderHeading();
-
     const summaryNode = this.renderSummary();
 
     return headingNode || summaryNode ? (
-      <header class={CSS.header} slot={SLOTS.headerContent}>
+      <div class={CSS.header} slot={SLOTS.headerContent}>
         {headingNode}
         {summaryNode}
-      </header>
+      </div>
     ) : null;
   }
 
@@ -349,10 +348,7 @@ export class CalciteFlowItem {
           })}
         >
           {this.renderBackButton(rtl)}
-          <div class={CSS.header} slot="header-content">
-            {this.renderHeading()}
-            {this.renderSummary()}
-          </div>
+          {this.renderHeader()}
           {this.renderHeaderActions()}
           <slot />
           {this.renderFooterActions()}


### PR DESCRIPTION
**Related Issue:** None

## Summary

chore: cleanup rendering of the header in flow item

Doesn't alter the dom structure at all, there was just a private method not being used that should be.
