### PR TITLE
fix: nesting and height issues

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -1,7 +1,7 @@
 :host {
   @extend %component-host;
   display: flex;
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   flex-direction: column;
   border-radius: var(--calcite-app-border-radius);
   margin: var(--calcite-app-cap-spacing-quarter) var(--calcite-app-side-spacing-quarter) 0;

--- a/src/components/calcite-flow-item/calcite-flow-item.scss
+++ b/src/components/calcite-flow-item/calcite-flow-item.scss
@@ -10,6 +10,7 @@
 
 calcite-panel {
   width: 100%;
+  height: 100%;
 }
 
 .header-content {

--- a/src/components/calcite-flow/calcite-flow.scss
+++ b/src/components/calcite-flow/calcite-flow.scss
@@ -5,6 +5,7 @@ $start-alpha: 0.5;
   align-items: stretch;
   display: flex;
   width: 100%;
+  height: 100%;
   overflow: hidden;
   position: relative;
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -9,6 +9,7 @@
   --calcite-app-shell-panel-width: 20vw;
   --calcite-app-shell-panel-min-width: 240px;
   --calcite-app-shell-panel-max-width: 360px;
+  --calcite-app-shell-panel-min-height: 4rem;
   --calcite-app-shell-panel-max-height-small: 35vh;
   --calcite-app-shell-panel-max-height-medium: 55vh;
   --calcite-app-shell-panel-max-height-large: 85vh;
@@ -25,6 +26,7 @@
   width: var(--calcite-app-shell-panel-width);
   min-width: var(--calcite-app-shell-panel-min-width);
   max-width: var(--calcite-app-shell-panel-max-width);
+  min-height: var(--calcite-app-shell-panel-min-height);
   border-left: 1px solid var(--calcite-app-border);
   border-right: 1px solid var(--calcite-app-border);
   padding: 0;


### PR DESCRIPTION
**Related Issue:** #771 

## Summary
Don't call it a comeback...but the 100% heights are making a comeback.
When in non-detached mode, the flow-item footers were not sticking to the bottom.

Outside components being but into flow-item will still need to set their own heights (i.e. to 100%).
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Would be nice to get this into a patch maybe?