### PR TITLE
fix(block): fix block toggling in Edge

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -80,11 +80,15 @@ calcite-loader[inline] {
 }
 
 .content {
-  padding: 0 var(--calcite-app-side-spacing-three-quarters) var(--calcite-app-cap-spacing-half);
   position: relative;
 }
 
+::slotted(*) {
+  padding: 0 var(--calcite-app-side-spacing-three-quarters) var(--calcite-app-cap-spacing-half);
+}
+
 ::slotted([slot="control"]) {
+  padding: unset;
   position: absolute;
   margin: auto;
   right: var(--calcite-app-side-spacing-three-quarters);

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -140,7 +140,6 @@ export class CalciteBlock {
     );
 
     const slottedControl = el.querySelector(`[slot=${SLOTS.control}]`);
-    const hasContent = el.children.length > (slottedControl ? 1 : 0);
 
     const headerNode = (
       <div class={CSS.headerContainer}>
@@ -171,7 +170,7 @@ export class CalciteBlock {
       <Host tabIndex={disabled ? -1 : null}>
         <article aria-expanded={collapsible ? open.toString() : null} aria-busy={loading}>
           {headerNode}
-          <div class={CSS.content} hidden={!hasContent || !open}>
+          <div class={CSS.content} hidden={!open}>
             <CalciteScrim loading={loading} disabled={disabled}>
               <slot />
             </CalciteScrim>

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -31,6 +31,15 @@
           <label slot="control">test <input placeholder="I'm a header control"/></label>
         </calcite-block>
 
+        <h2>Header + control + content (collapsible)</h2>
+
+        <calcite-block heading="With control + collapsible content" open collapsible>
+          <label slot="control">test <input placeholder="I'm a header control"/></label>
+          <calcite-block-section text="Animals" open>
+            <img alt="demo" src="https://placeimg.com/640/480/animals" />
+          </calcite-block-section>
+        </calcite-block>
+
         <h2>Icon + Header</h2>
 
         <calcite-block heading="Icon on header">


### PR DESCRIPTION
**Related Issue:** #763 

## Summary

<!--
If this is component-related, please verify that:

- [x] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [x] changes have been tested with demo page in Edge
-->

This restores block toggling in Edge. The issue was caused by the 'has content' logic, which caused the block to never open after being closed (`el.children` in Edge includes the elements in the render function, tripping up the logic). 
