### PR TITLE
chore(tests): update reflects test helper to handle camelCased props

### DIFF
--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -65,7 +65,7 @@ export async function reflects(
 
   for (const propAndValue of propsToTest) {
     const { propertyName, value } = propAndValue;
-    const componentAttributeSelector = `${componentTag}[${propertyName}]`;
+    const componentAttributeSelector = `${componentTag}[${propToAttr(propertyName)}]`;
 
     element.setProperty(propertyName, value);
     await page.waitForChanges();
@@ -84,6 +84,10 @@ export async function reflects(
       expect(await page.find(componentAttributeSelector)).toBeTruthy();
     }
   }
+}
+
+function propToAttr(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 }
 
 export async function defaults(


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

The `reflects` test helper uses prop names as is to build a selector. This needed to be updated to handle the prop-to-attr mapping built into web components.