### PR TITLE
fix(action): style updates for compact mode

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -24,10 +24,6 @@
   transition: color 125ms ease-in-out, fill 125ms ease-in-out, background-color 125ms ease-in-out;
   text-align: unset;
   position: relative;
-  &.button--compact {
-    padding-left: var(--calcite-app-side-spacing-quarter);
-    padding-right: var(--calcite-app-side-spacing-quarter);
-  }
 
   &:hover,
   &:focus {
@@ -80,6 +76,14 @@
 
 :host([scale="l"]) .button {
   padding: var(--calcite-app-cap-spacing-plus-half) var(--calcite-app-side-spacing-plus-half);
+}
+
+// Compact
+:host([scale="s"][compact]) .button,
+:host([scale="m"][compact]) .button,
+:host([scale="l"][compact]) .button {
+  padding-left: var(--calcite-app-side-spacing-quarter);
+  padding-right: var(--calcite-app-side-spacing-quarter);
 }
 
 .slot-container {


### PR DESCRIPTION
**Related Issue:** #759

## Summary
Additionally specific selectors for compact mode now that `scale` is a prop.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
cc @kat10140 