### PR TITLE
feat: deprecate layout in favor of position

### DIFF
--- a/.storybook/resources.ts
+++ b/.storybook/resources.ts
@@ -1,4 +1,4 @@
-import { CalciteAppearance, CalciteLayout, CalciteScale, CalciteTheme } from "../src/components/interfaces";
+import { CalciteAppearance, CalcitePosition, CalciteScale, CalciteTheme } from "../src/components/interfaces";
 
 type Direction = "ltr" | "rtl";
 
@@ -11,13 +11,13 @@ interface CommonAttributes {
   dir: AttributeMetadata<Direction>;
   theme: AttributeMetadata<CalciteTheme>;
   scale: AttributeMetadata<CalciteScale>;
-  layout: AttributeMetadata<CalciteLayout>;
+  position: AttributeMetadata<CalcitePosition>;
   appearance: AttributeMetadata<CalciteAppearance>;
 }
 
 const dirOptions: Direction[] = ["ltr", "rtl"];
 const themeOptions: CalciteTheme[] = ["light", "dark"];
-const layoutOptions: CalciteLayout[] = ["leading", "trailing"];
+const positionOptions: CalcitePosition[] = ["start", "end"];
 const scaleOptions: CalciteScale[] = ["s", "m", "l"];
 const appearanceOptions: CalciteAppearance[] = ["solid", "clear"];
 
@@ -34,9 +34,9 @@ export const ATTRIBUTES: CommonAttributes = {
     values: scaleOptions,
     defaultValue: scaleOptions[1]
   },
-  layout: {
-    values: layoutOptions,
-    defaultValue: layoutOptions[0]
+  position: {
+    values: positionOptions,
+    defaultValue: positionOptions[0]
   },
   appearance: {
     values: appearanceOptions,

--- a/src/components/calcite-action-bar/calcite-action-bar.stories.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.stories.ts
@@ -9,7 +9,7 @@ import {
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import dedent from "dedent";
-const { dir, layout, theme } = ATTRIBUTES;
+const { dir, position, theme } = ATTRIBUTES;
 
 export default {
   title: "components|calcite-action-bar",
@@ -45,8 +45,8 @@ const createAttributes: () => Attributes = () => [
     value: text("textCollapse", "Collapse")
   },
   {
-    name: "layout",
-    value: select("layout", layout.values, layout.defaultValue)
+    name: "position",
+    value: select("position", position.values, position.defaultValue)
   },
   {
     name: "theme",

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, Watch, h } from "@stencil/core";
 
-import { CalciteLayout, CalciteTheme } from "../interfaces";
+import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
 
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
 
@@ -60,8 +60,14 @@ export class CalciteActionBar {
   /**
    * Arrangement of the component. Leading and trailing are different depending on if the direction is LTR or RTL. For example, "leading"
    * in a LTR app will appear on the left.
+   * @deprecated()
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
+
+  /**
+   * Arranges the component depending on the elements 'dir' property.
+   */
+  @Prop({ reflect: true }) position: CalcitePosition;
 
   /**
    * Used to set the component's color scheme.
@@ -119,7 +125,7 @@ export class CalciteActionBar {
   // --------------------------------------------------------------------------
 
   renderBottomActionGroup() {
-    const { expanded, expand, textExpand, textCollapse, el, layout, toggleExpand } = this;
+    const { expanded, expand, textExpand, textCollapse, el, position, toggleExpand } = this;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -127,7 +133,7 @@ export class CalciteActionBar {
         textExpand={textExpand}
         textCollapse={textCollapse}
         el={el}
-        layout={layout}
+        position={position}
         toggleExpand={toggleExpand}
       />
     ) : null;

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -58,7 +58,9 @@ export class CalciteActionBar {
   @Prop() textCollapse = "Collapse";
 
   /**
-   * @deprecated Use `position` instead.
+   * @deprecated since 5.3 - use "position" instead.
+   * Arrangement of the component. Leading and trailing are different depending on if the direction is LTR or RTL. For example, "leading"
+   * in a LTR app will appear on the left.
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
 

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -1,10 +1,8 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, Watch, h } from "@stencil/core";
-
 import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
-
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
-
 import { CSS, SLOTS } from "./resources";
+import { getCalcitePosition } from "../utils/dom";
 
 /**
  * @slot bottom-actions - A slot for adding `calcite-action`s that will appear at the bottom of the action bar, above the collapse/expand button.
@@ -126,11 +124,6 @@ export class CalciteActionBar {
 
   renderBottomActionGroup() {
     const { expanded, expand, textExpand, textCollapse, el, layout, position, toggleExpand } = this;
-    const positionFallback: CalcitePosition = layout
-      ? layout === "trailing"
-        ? "end"
-        : "start"
-      : position;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -138,7 +131,7 @@ export class CalciteActionBar {
         textExpand={textExpand}
         textCollapse={textCollapse}
         el={el}
-        position={positionFallback}
+        position={getCalcitePosition(position, layout)}
         toggleExpand={toggleExpand}
       />
     ) : null;

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -125,7 +125,8 @@ export class CalciteActionBar {
   // --------------------------------------------------------------------------
 
   renderBottomActionGroup() {
-    const { expanded, expand, textExpand, textCollapse, el, position, toggleExpand } = this;
+    const { expanded, expand, textExpand, textCollapse, el, layout, position, toggleExpand } = this;
+    const positionFallback = layout ? (layout === "trailing" ? "end" : "start") : position;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -133,7 +134,7 @@ export class CalciteActionBar {
         textExpand={textExpand}
         textCollapse={textCollapse}
         el={el}
-        position={position}
+        position={positionFallback}
         toggleExpand={toggleExpand}
       />
     ) : null;

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -126,7 +126,11 @@ export class CalciteActionBar {
 
   renderBottomActionGroup() {
     const { expanded, expand, textExpand, textCollapse, el, layout, position, toggleExpand } = this;
-    const positionFallback = layout ? (layout === "trailing" ? "end" : "start") : position;
+    const positionFallback: CalcitePosition = layout
+      ? layout === "trailing"
+        ? "end"
+        : "start"
+      : position;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -58,9 +58,7 @@ export class CalciteActionBar {
   @Prop() textCollapse = "Collapse";
 
   /**
-   * Arrangement of the component. Leading and trailing are different depending on if the direction is LTR or RTL. For example, "leading"
-   * in a LTR app will appear on the left.
-   * @deprecated()
+   * @deprecated Use `position` instead.
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
 

--- a/src/components/calcite-action-pad/calcite-action-pad.stories.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.stories.ts
@@ -9,7 +9,7 @@ import {
 import readme from "./readme.md";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import dedent from "dedent";
-const { dir, layout, theme } = ATTRIBUTES;
+const { dir, position, theme } = ATTRIBUTES;
 
 export default {
   title: "components|calcite-action-pad",
@@ -37,8 +37,8 @@ const createAttributes: () => Attributes = () => [
     value: boolean("expanded", false)
   },
   {
-    name: "layout",
-    value: select("layout", layout.values, layout.defaultValue)
+    name: "position",
+    value: select("position", position.values, position.defaultValue)
   },
   {
     name: "text-expand",

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -123,7 +123,11 @@ export class CalciteActionPad {
 
   renderBottomActionGroup() {
     const { expanded, expand, textExpand, textCollapse, el, layout, position, toggleExpand } = this;
-    const positionFallback = layout ? (layout === "trailing" ? "end" : "start") : position;
+    const positionFallback: CalcitePosition = layout
+      ? layout === "trailing"
+        ? "end"
+        : "start"
+      : position;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -1,10 +1,8 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, Watch, h } from "@stencil/core";
-
 import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
-
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
-
 import { CSS } from "./resources";
+import { getCalcitePosition } from "../utils/dom";
 
 /**
  * @slot - A slot for adding `calcite-action`s to the action pad.
@@ -123,11 +121,6 @@ export class CalciteActionPad {
 
   renderBottomActionGroup() {
     const { expanded, expand, textExpand, textCollapse, el, layout, position, toggleExpand } = this;
-    const positionFallback: CalcitePosition = layout
-      ? layout === "trailing"
-        ? "end"
-        : "start"
-      : position;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -135,7 +128,7 @@ export class CalciteActionPad {
         textExpand={textExpand}
         textCollapse={textCollapse}
         el={el}
-        position={positionFallback}
+        position={getCalcitePosition(position, layout)}
         toggleExpand={toggleExpand}
       />
     ) : null;

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, Watch, h } from "@stencil/core";
 
-import { CalciteLayout, CalciteTheme } from "../interfaces";
+import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
 
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
 
@@ -58,8 +58,14 @@ export class CalciteActionPad {
 
   /**
    * Arrangement of the component.
+   * @deprecated()
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
+
+  /**
+   * Arranges the component depending on the elements 'dir' property.
+   */
+  @Prop({ reflect: true }) position: CalcitePosition;
 
   /**
    * Used to set the component's color scheme.
@@ -116,7 +122,7 @@ export class CalciteActionPad {
   // --------------------------------------------------------------------------
 
   renderBottomActionGroup() {
-    const { expanded, expand, textExpand, textCollapse, el, layout, toggleExpand } = this;
+    const { expanded, expand, textExpand, textCollapse, el, position, toggleExpand } = this;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -124,7 +130,7 @@ export class CalciteActionPad {
         textExpand={textExpand}
         textCollapse={textCollapse}
         el={el}
-        layout={layout}
+        position={position}
         toggleExpand={toggleExpand}
       />
     ) : null;

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -122,7 +122,8 @@ export class CalciteActionPad {
   // --------------------------------------------------------------------------
 
   renderBottomActionGroup() {
-    const { expanded, expand, textExpand, textCollapse, el, position, toggleExpand } = this;
+    const { expanded, expand, textExpand, textCollapse, el, layout, position, toggleExpand } = this;
+    const positionFallback = layout ? (layout === "trailing" ? "end" : "start") : position;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -130,7 +131,7 @@ export class CalciteActionPad {
         textExpand={textExpand}
         textCollapse={textCollapse}
         el={el}
-        position={position}
+        position={positionFallback}
         toggleExpand={toggleExpand}
       />
     ) : null;

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -57,8 +57,7 @@ export class CalciteActionPad {
   @Prop() textCollapse = "Collapse";
 
   /**
-   * Arrangement of the component.
-   * @deprecated()
+   * @deprecated Use `position` instead.
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
 

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -57,7 +57,8 @@ export class CalciteActionPad {
   @Prop() textCollapse = "Collapse";
 
   /**
-   * @deprecated Use `position` instead.
+   * @deprecated since 5.3 - use "position" instead.
+   * Arrangement of the component.
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -74,7 +74,21 @@ describe("calcite-shell-panel", () => {
     expect(eventSpy).toHaveReceivedEvent();
   });
 
-  it("leading position property should have action slot first ", async () => {
+  it("deprecated: leading layout property should have action slot first", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<calcite-shell-panel layout="leading"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
+    );
+
+    const element = await page.find("calcite-shell-panel");
+
+    await page.waitForChanges();
+
+    expect(element.shadowRoot.firstElementChild.tagName).toBe("SLOT");
+  });
+
+  it("start position property should have action slot first", async () => {
     const page = await newE2EPage();
 
     await page.setContent(
@@ -88,7 +102,21 @@ describe("calcite-shell-panel", () => {
     expect(element.shadowRoot.firstElementChild.tagName).toBe("SLOT");
   });
 
-  it("trailing position property should have DIV first ", async () => {
+  it("deprecated: trailing layout property should have DIV first", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<calcite-shell-panel layout="trailing"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
+    );
+
+    const element = await page.find("calcite-shell-panel");
+
+    await page.waitForChanges();
+
+    expect(element.shadowRoot.firstElementChild.tagName).toBe("DIV");
+  });
+
+  it("trailing position property should have DIV first", async () => {
     const page = await newE2EPage();
 
     await page.setContent(

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -11,8 +11,8 @@ describe("calcite-shell-panel", () => {
   it("defaults", async () =>
     defaults("calcite-shell-panel", [
       {
-        propertyName: "layout",
-        defaultValue: "leading"
+        propertyName: "position",
+        defaultValue: "start"
       },
       {
         propertyName: "collapsed",
@@ -78,11 +78,11 @@ describe("calcite-shell-panel", () => {
     expect(eventSpy).toHaveReceivedEvent();
   });
 
-  it("leading layout property should have action slot first ", async () => {
+  it("leading position property should have action slot first ", async () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      '<calcite-shell-panel layout="leading"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
+      '<calcite-shell-panel position="start"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
     );
 
     const element = await page.find("calcite-shell-panel");
@@ -92,11 +92,11 @@ describe("calcite-shell-panel", () => {
     expect(element.shadowRoot.firstElementChild.tagName).toBe("SLOT");
   });
 
-  it("trailing layout property should have DIV first ", async () => {
+  it("trailing position property should have DIV first ", async () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      '<calcite-shell-panel layout="trailing"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
+      '<calcite-shell-panel position="end"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
     );
 
     const element = await page.find("calcite-shell-panel");
@@ -108,7 +108,7 @@ describe("calcite-shell-panel", () => {
 
   it("should be accessible", async () =>
     accessible(`
-    <calcite-shell-panel slot="primary-panel" layout="leading">
+    <calcite-shell-panel slot="primary-panel" position="start">
       <calcite-action-bar slot="action-bar">
         <calcite-action-group>
           <calcite-action text="Add">

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -11,10 +11,6 @@ describe("calcite-shell-panel", () => {
   it("defaults", async () =>
     defaults("calcite-shell-panel", [
       {
-        propertyName: "position",
-        defaultValue: "start"
-      },
-      {
         propertyName: "collapsed",
         defaultValue: false
       }

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -53,9 +53,9 @@
   display: none;
 }
 
-:host([layout="leading"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
+:host([position="start"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
   border-right: 1px solid var(--calcite-app-border);
 }
-:host([layout="trailing"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
+:host([position="end"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
   border-left: 1px solid var(--calcite-app-border);
 }

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -69,7 +69,11 @@ export class CalciteShellPanel {
 
   render() {
     const { collapsed, detached, layout, position } = this;
-    const positionFallback = layout ? (layout === "trailing" ? "end" : "start") : position;
+    const positionFallback: CalcitePosition = layout
+      ? layout === "trailing"
+        ? "end"
+        : "start"
+      : position || "start";
 
     const contentNode = (
       <div class={classnames(CSS.content, { [CSS.contentDetached]: detached })} hidden={collapsed}>

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -40,8 +40,7 @@ export class CalciteShellPanel {
   @Prop({ reflect: false }) detachedScale: CalciteScale = "m";
 
   /**
-   * Arrangement of the component.
-   * @deprecated()
+   * @deprecated Use `position` instead.
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -2,6 +2,7 @@ import classnames from "classnames";
 import { Component, Event, EventEmitter, Host, Prop, Watch, h } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { CalciteLayout, CalcitePosition, CalciteScale } from "../interfaces";
+import { getCalcitePosition } from "../utils/dom";
 
 /**
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
@@ -69,11 +70,6 @@ export class CalciteShellPanel {
 
   render() {
     const { collapsed, detached, layout, position } = this;
-    const positionFallback: CalcitePosition = layout
-      ? layout === "trailing"
-        ? "end"
-        : "start"
-      : position || "start";
 
     const contentNode = (
       <div class={classnames(CSS.content, { [CSS.contentDetached]: detached })} hidden={collapsed}>
@@ -85,7 +81,7 @@ export class CalciteShellPanel {
 
     const mainNodes = [actionBarNode, contentNode];
 
-    if (positionFallback === "end") {
+    if (getCalcitePosition(position, layout) === "end") {
       mainNodes.reverse();
     }
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -1,7 +1,7 @@
 import classnames from "classnames";
 import { Component, Event, EventEmitter, Host, Prop, Watch, h } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
-import { CalciteLayout, CalciteScale } from "../interfaces";
+import { CalciteLayout, CalcitePosition, CalciteScale } from "../interfaces";
 
 /**
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
@@ -41,8 +41,14 @@ export class CalciteShellPanel {
 
   /**
    * Arrangement of the component.
+   * @deprecated()
    */
   @Prop({ reflect: true }) layout: CalciteLayout = "leading";
+
+  /**
+   * Arranges the component depending on the elements 'dir' property.
+   */
+  @Prop({ reflect: true }) position: CalcitePosition;
 
   // --------------------------------------------------------------------------
   //
@@ -62,7 +68,7 @@ export class CalciteShellPanel {
   // --------------------------------------------------------------------------
 
   render() {
-    const { collapsed, detached, layout } = this;
+    const { collapsed, detached, position } = this;
 
     const contentNode = (
       <div class={classnames(CSS.content, { [CSS.contentDetached]: detached })} hidden={collapsed}>
@@ -74,7 +80,7 @@ export class CalciteShellPanel {
 
     const mainNodes = [actionBarNode, contentNode];
 
-    if (layout === "trailing") {
+    if (position === "end") {
       mainNodes.reverse();
     }
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -40,7 +40,8 @@ export class CalciteShellPanel {
   @Prop({ reflect: false }) detachedScale: CalciteScale = "m";
 
   /**
-   * @deprecated Use `position` instead.
+   * @deprecated since 5.3 - use "position" instead.
+   * Arrangement of the component.
    */
   @Prop({ reflect: true }) layout: CalciteLayout;
 

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -43,7 +43,7 @@ export class CalciteShellPanel {
    * Arrangement of the component.
    * @deprecated()
    */
-  @Prop({ reflect: true }) layout: CalciteLayout = "leading";
+  @Prop({ reflect: true }) layout: CalciteLayout;
 
   /**
    * Arranges the component depending on the elements 'dir' property.
@@ -68,7 +68,8 @@ export class CalciteShellPanel {
   // --------------------------------------------------------------------------
 
   render() {
-    const { collapsed, detached, position } = this;
+    const { collapsed, detached, layout, position } = this;
+    const positionFallback = layout ? (layout === "trailing" ? "end" : "start") : position;
 
     const contentNode = (
       <div class={classnames(CSS.content, { [CSS.contentDetached]: detached })} hidden={collapsed}>
@@ -80,7 +81,7 @@ export class CalciteShellPanel {
 
     const mainNodes = [actionBarNode, contentNode];
 
-    if (position === "end") {
+    if (positionFallback === "end") {
       mainNodes.reverse();
     }
 

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -42,10 +42,10 @@ describe("calcite-shell", () => {
   it("should be accessible", async () =>
     accessible(`
     <calcite-shell>
-      <calcite-shell-panel slot="${SLOTS.primaryPanel}" layout="leading">
+      <calcite-shell-panel slot="${SLOTS.primaryPanel}" position="start">
         <p>Primary Content</p>
       </calcite-shell-panel>
-      <calcite-shell-panel slot="${SLOTS.contextualPanel}" layout="trailing">
+      <calcite-shell-panel slot="${SLOTS.contextualPanel}" position="end">
         <p>Primary Content</p>
       </calcite-shell-panel>
     </calcite-shell>
@@ -55,10 +55,10 @@ describe("calcite-shell", () => {
     const page = await newE2EPage();
 
     await page.setContent(`<calcite-shell>
-    <calcite-shell-panel slot="${SLOTS.primaryPanel}" layout="leading">
+    <calcite-shell-panel slot="${SLOTS.primaryPanel}" position="start">
       <p>Primary Content</p>
     </calcite-shell-panel>
-    <calcite-shell-panel slot="${SLOTS.contextualPanel}" layout="trailing">
+    <calcite-shell-panel slot="${SLOTS.contextualPanel}" position="end">
       <p>Primary Content</p>
     </calcite-shell-panel>
   </calcite-shell>`);
@@ -74,10 +74,10 @@ describe("calcite-shell", () => {
     const page = await newE2EPage();
 
     await page.setContent(`<calcite-shell>
-    <calcite-shell-panel slot="${SLOTS.primaryPanel}" layout="trailing">
+    <calcite-shell-panel slot="${SLOTS.primaryPanel}" position="start">
       <p>Primary Content</p>
     </calcite-shell-panel>
-    <calcite-shell-panel slot="${SLOTS.contextualPanel}" layout="leading">
+    <calcite-shell-panel slot="${SLOTS.contextualPanel}" position="end">
       <p>Primary Content</p>
     </calcite-shell-panel>
   </calcite-shell>`);

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -51,6 +51,25 @@ describe("calcite-shell", () => {
     </calcite-shell>
     `));
 
+  it("deprecated: flex row should not be reversed", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-shell>
+      <calcite-shell-panel slot="${SLOTS.primaryPanel}" layout="leading">
+        <p>Primary Content</p>
+      </calcite-shell-panel>
+      <calcite-shell-panel slot="${SLOTS.contextualPanel}" layout="trailing">
+        <p>Primary Content</p>
+      </calcite-shell-panel>
+    </calcite-shell>`);
+
+    await page.waitForChanges();
+
+    const mainReversed = await page.find(`calcite-shell >>> .${CSS.mainReversed}`);
+
+    expect(mainReversed).toBeNull();
+  });
+
   it("flex row should not be reversed", async () => {
     const page = await newE2EPage();
 
@@ -68,6 +87,25 @@ describe("calcite-shell", () => {
     const mainReversed = await page.find(`calcite-shell >>> .${CSS.mainReversed}`);
 
     expect(mainReversed).toBeNull();
+  });
+
+  it("deprecated: flex row should be reversed", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`<calcite-shell>
+    <calcite-shell-panel slot="${SLOTS.primaryPanel}" layout="trailing">
+      <p>Primary Content</p>
+    </calcite-shell-panel>
+    <calcite-shell-panel slot="${SLOTS.contextualPanel}" layout="leading">
+      <p>Primary Content</p>
+    </calcite-shell-panel>
+  </calcite-shell>`);
+
+    await page.waitForChanges();
+
+    const mainReversed = await page.find(`calcite-shell >>> .${CSS.mainReversed}`);
+
+    expect(mainReversed).not.toBeNull();
   });
 
   it("flex row should be reversed", async () => {

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -74,10 +74,10 @@ describe("calcite-shell", () => {
     const page = await newE2EPage();
 
     await page.setContent(`<calcite-shell>
-    <calcite-shell-panel slot="${SLOTS.primaryPanel}" position="start">
+    <calcite-shell-panel slot="${SLOTS.primaryPanel}" position="end">
       <p>Primary Content</p>
     </calcite-shell-panel>
-    <calcite-shell-panel slot="${SLOTS.contextualPanel}" position="end">
+    <calcite-shell-panel slot="${SLOTS.contextualPanel}" position="start">
       <p>Primary Content</p>
     </calcite-shell-panel>
   </calcite-shell>`);

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -7,7 +7,7 @@ import {
   titlelessDocsPage
 } from "../../../.storybook/utils";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-const { dir, layout, scale, theme } = ATTRIBUTES;
+const { dir, position, scale, theme } = ATTRIBUTES;
 import readme from "./readme.md";
 import panelReadme from "../calcite-shell-panel/readme.md";
 import dedent from "dedent";
@@ -59,8 +59,13 @@ const createShellPanelAttributes: (group: "Leading Panel" | "Trailing Panel") =>
       value: select("detachedScale", scale.values, scale.defaultValue, group)
     },
     {
-      name: "layout",
-      value: select("layout", layout.values, group === "Leading Panel" ? layout.values[0] : layout.values[1], group)
+      name: "position",
+      value: select(
+        "position",
+        position.values,
+        group === "Leading Panel" ? position.values[0] : position.values[1],
+        group
+      )
     }
   ];
 };

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -72,7 +72,7 @@ export class CalciteShell {
     ) as HTMLCalciteShellPanelElement;
 
     const mainClasses = {
-      [CSS.mainReversed]: primaryPanel?.layout === "trailing"
+      [CSS.mainReversed]: primaryPanel?.position === "end"
     };
 
     return (

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Host, Prop, h } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { CalciteTheme } from "../interfaces";
 import classnames from "classnames";
+import { getCalcitePosition } from "../utils/dom";
 
 /**
  * @slot shell-header - A slot for adding header content. This content will be positioned at the top of the shell.
@@ -72,7 +73,7 @@ export class CalciteShell {
     ) as HTMLCalciteShellPanelElement;
 
     const mainClasses = {
-      [CSS.mainReversed]: primaryPanel?.position === "end"
+      [CSS.mainReversed]: getCalcitePosition(primaryPanel?.position, primaryPanel?.layout) === "end"
     };
 
     return (

--- a/src/components/calcite-shell/readme.md
+++ b/src/components/calcite-shell/readme.md
@@ -17,7 +17,7 @@ note: calcite-icon is pulled in from [calcite-components](https://esri.github.io
 
 ```html
 <calcite-shell>
-  <calcite-shell-panel slot="primary-panel" layout="leading" detached>
+  <calcite-shell-panel slot="primary-panel" position="start" detached>
     <calcite-action-bar slot="action-bar" theme="dark">
       <calcite-action-group>
         <calcite-action text="Add">
@@ -59,7 +59,7 @@ note: calcite-icon is pulled in from [calcite-components](https://esri.github.io
     </calcite-block>
   </calcite-shell-panel>
 
-   <calcite-shell-panel slot="contextual-panel" layout="trailing" detached detached-scale="l">
+   <calcite-shell-panel slot="contextual-panel" position="end" detached detached-scale="l">
       <calcite-action-bar slot="action-bar">
         <calcite-action-group>
           <calcite-action text="Add" active>
@@ -146,10 +146,10 @@ Renders a shell with a header and panels on the left and right sides of the app.
 
 ```html
 <calcite-shell>
-  <calcite-shell-panel slot="primary-panel" layout="leading">
+  <calcite-shell-panel slot="primary-panel" position="start">
     Leading panel! (on the left side, since this is a LTR app)
   </calcite-shell-panel>
-  <calcite-shell-panel slot="contextual-panel" layout="trailing">
+  <calcite-shell-panel slot="contextual-panel" position="end">
     Trailing panel! (right side)
   </calcite-shell-panel>
   <div slot="shell-header">
@@ -168,7 +168,7 @@ Renders a single panel with actions in an action bar.
 
 ```html
 <calcite-shell>
-  <calcite-shell-panel slot="primary-panel" layout="leading">
+  <calcite-shell-panel slot="primary-panel" position="start">
     <img src="https://via.placeholder.com/300x200" alt="placeholder" />
     <calcite-action-bar slot="action-bar">
       <calcite-action text="Add" active>

--- a/src/components/calcite-shell/usage/advanced.md
+++ b/src/components/calcite-shell/usage/advanced.md
@@ -5,7 +5,7 @@ note: calcite-icon is pulled in from [calcite-components](https://esri.github.io
 
 ```html
 <calcite-shell>
-  <calcite-shell-panel slot="primary-panel" layout="leading" detached>
+  <calcite-shell-panel slot="primary-panel" position="start" detached>
     <calcite-action-bar slot="action-bar" theme="dark">
       <calcite-action-group>
         <calcite-action text="Add">
@@ -47,7 +47,7 @@ note: calcite-icon is pulled in from [calcite-components](https://esri.github.io
     </calcite-block>
   </calcite-shell-panel>
 
-   <calcite-shell-panel slot="contextual-panel" layout="trailing" detached detached-scale="l">
+   <calcite-shell-panel slot="contextual-panel" position="end" detached detached-scale="l">
       <calcite-action-bar slot="action-bar">
         <calcite-action-group>
           <calcite-action text="Add" active>

--- a/src/components/calcite-shell/usage/basic.md
+++ b/src/components/calcite-shell/usage/basic.md
@@ -21,10 +21,10 @@ Renders a shell with a header and panels on the left and right sides of the app.
 
 ```html
 <calcite-shell>
-  <calcite-shell-panel slot="primary-panel" layout="leading">
+  <calcite-shell-panel slot="primary-panel" position="start">
     Leading panel! (on the left side, since this is a LTR app)
   </calcite-shell-panel>
-  <calcite-shell-panel slot="contextual-panel" layout="trailing">
+  <calcite-shell-panel slot="contextual-panel" position="end">
     Trailing panel! (right side)
   </calcite-shell-panel>
   <div slot="shell-header">
@@ -43,7 +43,7 @@ Renders a single panel with actions in an action bar.
 
 ```html
 <calcite-shell>
-  <calcite-shell-panel slot="primary-panel" layout="leading">
+  <calcite-shell-panel slot="primary-panel" position="start">
     <img src="https://via.placeholder.com/300x200" alt="placeholder" />
     <calcite-action-bar slot="action-bar">
       <calcite-action text="Add" active>

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -2,6 +2,8 @@
 
 export type CalciteLayout = "leading" | "trailing";
 
+export type CalcitePosition = "start" | "end";
+
 export type CalciteTheme = "light" | "dark";
 
 export type CalciteBlockSectionToggleDisplay = "button" | "switch";

--- a/src/components/utils/CalciteExpandToggle.tsx
+++ b/src/components/utils/CalciteExpandToggle.tsx
@@ -26,6 +26,10 @@ function getClosestShellPosition(el: HTMLElement): CalcitePosition | null {
   return shellNode.position;
 }
 
+function getCalcitePosition(position: CalcitePosition, el: HTMLElement) {
+  return position || getClosestShellPosition(el) || "start";
+}
+
 export function toggleChildActionText({
   parent,
   expanded
@@ -53,9 +57,7 @@ export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> 
     icons.reverse();
   }
 
-  const positionFallback = position || getClosestShellPosition(el) || "start";
-
-  const end = positionFallback === "end";
+  const end = getCalcitePosition(position, el) === "end";
   const expandIcon = end ? icons[1] : icons[0];
   const collapseIcon = end ? icons[0] : icons[1];
 

--- a/src/components/utils/CalciteExpandToggle.tsx
+++ b/src/components/utils/CalciteExpandToggle.tsx
@@ -1,13 +1,13 @@
 import { FunctionalComponent, h } from "@stencil/core";
 import { getElementDir } from "./dom";
-import { CalciteLayout } from "../interfaces";
+import { CalcitePosition } from "../interfaces";
 
 interface CalciteExpandToggleProps {
   expanded: boolean;
   textExpand: string;
   textCollapse: string;
   el: HTMLElement;
-  layout: CalciteLayout;
+  position: CalcitePosition;
   toggleExpand: () => void;
 }
 
@@ -16,14 +16,14 @@ const ICONS = {
   chevronsRight: "chevrons-right"
 };
 
-function getClosestShellLayout(el: HTMLElement): CalciteLayout | null {
+function getClosestShellPosition(el: HTMLElement): CalcitePosition | null {
   const shellNode = el.closest("calcite-shell-panel");
 
   if (!shellNode) {
     return;
   }
 
-  return shellNode.layout;
+  return shellNode.position;
 }
 
 export function toggleChildActionText({
@@ -42,7 +42,7 @@ export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> 
   textCollapse,
   toggleExpand,
   el,
-  layout
+  position
 }) => {
   const rtl = getElementDir(el) === "rtl";
 
@@ -53,11 +53,11 @@ export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> 
     icons.reverse();
   }
 
-  const layoutFallback = layout || getClosestShellLayout(el) || "leading";
+  const positionFallback = position || getClosestShellPosition(el) || "start";
 
-  const trailing = layoutFallback === "trailing";
-  const expandIcon = trailing ? icons[1] : icons[0];
-  const collapseIcon = trailing ? icons[0] : icons[1];
+  const end = positionFallback === "end";
+  const expandIcon = end ? icons[1] : icons[0];
+  const collapseIcon = end ? icons[0] : icons[1];
 
   return (
     <calcite-action onClick={toggleExpand} textEnabled={expanded} text={expandText}>

--- a/src/components/utils/dom.ts
+++ b/src/components/utils/dom.ts
@@ -1,3 +1,5 @@
+import { CalciteLayout, CalcitePosition } from "../interfaces";
+
 export function getElementDir(el: HTMLElement) {
   return getElementProp(el, "dir", "ltr");
 }
@@ -17,4 +19,16 @@ export function focusElement(el: CalciteFocusableElement): void {
   }
 
   "setFocus" in el && typeof el.setFocus === "function" ? el.setFocus() : el.focus();
+}
+
+export function getCalcitePosition(position: CalcitePosition, layout: CalciteLayout): CalcitePosition {
+  if (position) {
+    return position;
+  }
+
+  if (layout) {
+    return layout === "trailing" ? "end" : "start";
+  }
+
+  return "start";
 }

--- a/src/demos/shell-panel/basic.html
+++ b/src/demos/shell-panel/basic.html
@@ -41,8 +41,8 @@
           </div>
         </calcite-shell-panel>
 
-        <h2>Trailing layout</h2>
-        <calcite-shell-panel layout="trailing">
+        <h2>End Position</h2>
+        <calcite-shell-panel position="end">
           <p>Primary Content</p>
           <div slot="action-bar">
             <div><img src="https://via.placeholder.com/48x48" alt="placeholder" /></div>
@@ -68,8 +68,8 @@
             </div>
           </calcite-shell-panel>
 
-          <h3>Trailing layout</h3>
-          <calcite-shell-panel layout="trailing">
+          <h3>End Position</h3>
+          <calcite-shell-panel position="end">
             <p>Primary Content</p>
             <div slot="action-bar">
               <div><img src="https://via.placeholder.com/48x48" alt="placeholder" /></div>

--- a/src/demos/shell/basic.html
+++ b/src/demos/shell/basic.html
@@ -69,11 +69,11 @@
         <h2>Shell with Panels</h2>
         <div class="shell-container">
           <calcite-shell>
-            <calcite-shell-panel slot="primary-panel" layout="leading">
+            <calcite-shell-panel slot="primary-panel" position="start">
               leading panel
             </calcite-shell-panel>
 
-            <calcite-shell-panel slot="contextual-panel" layout="trailing">
+            <calcite-shell-panel slot="contextual-panel" position="end">
               trailing panel
             </calcite-shell-panel>
             <div slot="shell-header">

--- a/src/demos/shell/demo-app-full-window-reversed.html
+++ b/src/demos/shell/demo-app-full-window-reversed.html
@@ -46,7 +46,7 @@
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel slot="primary-panel" layout="trailing" detached>
+          <calcite-shell-panel slot="primary-panel" position="end" detached>
             <calcite-panel
               id="shell-floating-panel"
               slot="shell-floating-panel"
@@ -176,7 +176,7 @@
               </calcite-block>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" layout="leading" detached detached-scale="l">
+          <calcite-shell-panel slot="contextual-panel" position="start" detached detached-scale="l">
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Add" active>

--- a/src/demos/shell/demo-app-full-window.html
+++ b/src/demos/shell/demo-app-full-window.html
@@ -49,7 +49,7 @@
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel slot="primary-panel" layout="leading" detached>
+          <calcite-shell-panel slot="primary-panel" position="start" detached>
             <calcite-panel
               id="shell-floating-panel"
               slot="shell-floating-panel"
@@ -145,7 +145,7 @@
             </calcite-block>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" layout="trailing" detached detached-scale="l">
+          <calcite-shell-panel slot="contextual-panel" position="end" detached detached-scale="l">
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Add" active>

--- a/src/demos/shell/demo-app-rtl.html
+++ b/src/demos/shell/demo-app-rtl.html
@@ -77,7 +77,7 @@
         <h2>Light Theme</h2>
         <div class="shell-container">
           <calcite-shell>
-            <calcite-shell-panel slot="primary-panel" layout="leading">
+            <calcite-shell-panel slot="primary-panel" position="start">
               <calcite-action-bar slot="action-bar" theme="dark">
                 <calcite-action-group>
                   <calcite-action text="Add">
@@ -144,7 +144,7 @@
               </div>
             </calcite-shell-panel>
 
-            <calcite-shell-panel slot="contextual-panel" layout="trailing">
+            <calcite-shell-panel slot="contextual-panel" position="end">
               <calcite-action-bar slot="action-bar">
                 <calcite-action-group>
                   <calcite-action text="Add" active>
@@ -250,7 +250,7 @@
 
         <div class="shell-container">
           <calcite-shell theme="dark">
-            <calcite-shell-panel slot="primary-panel" layout="leading">
+            <calcite-shell-panel slot="primary-panel" position="start">
               <calcite-action-pad hidden>
                 <calcite-action-group>
                   <calcite-action text="Add">
@@ -320,7 +320,7 @@
               </div>
             </calcite-shell-panel>
 
-            <calcite-shell-panel slot="contextual-panel" layout="trailing">
+            <calcite-shell-panel slot="contextual-panel" position="end">
               <calcite-action-bar slot="action-bar">
                 <calcite-action-group>
                   <calcite-action text="Add">

--- a/src/demos/shell/demo-app.html
+++ b/src/demos/shell/demo-app.html
@@ -75,7 +75,7 @@
         <h2>Light Theme</h2>
         <div class="shell-container">
           <calcite-shell>
-            <calcite-shell-panel slot="primary-panel" layout="leading">
+            <calcite-shell-panel slot="primary-panel" position="start">
               <calcite-action-bar slot="action-bar" theme="dark">
                 <calcite-action-group>
                   <calcite-action text="Add">
@@ -142,7 +142,7 @@
               </div>
             </calcite-shell-panel>
 
-            <calcite-shell-panel slot="contextual-panel" layout="trailing">
+            <calcite-shell-panel slot="contextual-panel" position="end">
               <calcite-action-bar slot="action-bar">
                 <calcite-action-group>
                   <calcite-action text="Add" active>
@@ -298,7 +298,7 @@
 
         <div class="shell-container">
           <calcite-shell theme="dark">
-            <calcite-shell-panel slot="primary-panel" layout="leading">
+            <calcite-shell-panel slot="primary-panel" position="start">
               <calcite-action-pad hidden>
                 <calcite-action-group>
                   <calcite-action text="Add">
@@ -368,7 +368,7 @@
               </div>
             </calcite-shell-panel>
 
-            <calcite-shell-panel slot="contextual-panel" layout="trailing">
+            <calcite-shell-panel slot="contextual-panel" position="end">
               <calcite-action-bar slot="action-bar">
                 <calcite-action-group>
                   <calcite-action text="Add">

--- a/src/demos/shell/panel-with-action-bar.html
+++ b/src/demos/shell/panel-with-action-bar.html
@@ -26,7 +26,7 @@
         </p>
 
         <h2>Basic Shell Panel</h2>
-        <calcite-shell-panel slot="primary-panel" layout="leading">
+        <calcite-shell-panel slot="primary-panel" position="start">
           <img src="https://via.placeholder.com/300x200" alt="placeholder" />
           <calcite-action-bar slot="action-bar">
             <calcite-action-group>


### PR DESCRIPTION
**Related Issue:** None

## Summary

- Deprecate use of `layout` property.
- Add `position` property which can be `start` or `end`.

https://github.com/Esri/calcite-components/pull/325#discussion_r376087970