### PR TITLE
chore(demos): tidy up test pages

### DIFF
--- a/src/demos/action-bar/add-action-after-init.html
+++ b/src/demos/action-bar/add-action-after-init.html
@@ -1,77 +1,69 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
 
-    <title>Calcite App Components:</title>
+  <title>Calcite App Components:</title>
 
-    <!-- Loads the link and script tags-->
-    <script src="../_assets/head.js"></script>
-    <script src="../_assets/toggles.js"></script>
-    <style>
-      .flexxed {
-        display: flex;
-        align-items: flex-start;
-      }
+  <script src="../_assets/head.js"></script>
+  <script src="../_assets/toggles.js"></script>
+  <style>
+    .flexxed {
+      display: flex;
+      align-items: flex-start;
+    }
 
-      .flexxed section {
-        margin: 0 12px;
-      }
-      .action-bar-container {
-        height: 600px;
-      }
-    </style>
-  </head>
+    .flexxed section {
+      margin: 0 12px;
+    }
+  </style>
+</head>
 
-  <body>
-    <main>
-      <section class="example-container">
-        <h1>calcite-action-bar</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-action-bar/readme.md"
-            >calcite-action-bar readme.</a
-          >
-        </p>
-        <div class="flexxed">
-          <section>
-            <h2>LTR</h2>
-            <div class="flexxed">
-              <section>
-                <h3>Bottom Actions</h3>
-                <calcite-action-bar id="slot-test">
-                  <calcite-action text="Add">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
-                      <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
-                    </svg>
-                  </calcite-action>
-                  <calcite-action text="Save">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
-                      <path
-                        d="M14 1H2a1 1 0 0 0-1 1v10a.99.99 0 0 0 .293.707l2 2A.995.995 0 0 0 4 15h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 14v-3h2v3zm6-.001V14h-1v-4H5v4H4v-4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1zM12 6H4V2h8z"
-                      />
-                    </svg>
-                  </calcite-action>
-                </calcite-action-bar>
+<body>
+  <main>
+    <section class="example-container">
+      <h1>calcite-action-bar</h1>
 
-                <script>
-                  var slotTestNode = document.getElementById("slot-test");
-                  setTimeout(function() {
-                    var action = document.createElement("calcite-action");
-                    action.setAttribute("slot", "bottom-actions");
-                    action.setAttribute("text", "Hello world");
-                    action.innerHTML = `<calcite-icon scale="s" icon="layers"></calcite-icon>`;
-                    slotTestNode.appendChild(action);
-                  }, 2000);
-                </script>
-              </section>
-              </div>
-            </div>
-          </section>
-        </div>
-      </section>
-    </main>
-  </body>
+      <div class="flexxed">
+        <section>
+          <h2>LTR</h2>
+          <div class="flexxed">
+            <section>
+              <h3>Bottom Actions</h3>
+              <calcite-action-bar id="slot-test">
+                <calcite-action text="Add">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
+                       width="16" height="16">
+                    <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
+                  </svg>
+                </calcite-action>
+                <calcite-action text="Save">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
+                       width="16" height="16">
+                    <path
+                      d="M14 1H2a1 1 0 0 0-1 1v10a.99.99 0 0 0 .293.707l2 2A.995.995 0 0 0 4 15h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 14v-3h2v3zm6-.001V14h-1v-4H5v4H4v-4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1zM12 6H4V2h8z"
+                    />
+                  </svg>
+                </calcite-action>
+              </calcite-action-bar>
+
+              <script>
+                const slotTestNode = document.getElementById("slot-test");
+                setTimeout(function() {
+                  const action = document.createElement("calcite-action");
+                  action.setAttribute("slot", "bottom-actions");
+                  action.setAttribute("text", "Hello world");
+                  action.innerHTML = `<calcite-icon scale="s" icon="layers"></calcite-icon>`;
+                  slotTestNode.appendChild(action);
+                }, 2000);
+              </script>
+            </section>
+          </div>
+        </section>
+      </div>
+    </section>
+  </main>
+</body>
 </html>

--- a/src/demos/action-bar/add-action-after-init.html
+++ b/src/demos/action-bar/add-action-after-init.html
@@ -34,18 +34,10 @@
               <h3>Bottom Actions</h3>
               <calcite-action-bar id="slot-test">
                 <calcite-action text="Add">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
-                       width="16" height="16">
-                    <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
-                  </svg>
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Save">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
-                       width="16" height="16">
-                    <path
-                      d="M14 1H2a1 1 0 0 0-1 1v10a.99.99 0 0 0 .293.707l2 2A.995.995 0 0 0 4 15h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 14v-3h2v3zm6-.001V14h-1v-4H5v4H4v-4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1zM12 6H4V2h8z"
-                    />
-                  </svg>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
                 </calcite-action>
               </calcite-action-bar>
 

--- a/src/demos/action-bar/basic.html
+++ b/src/demos/action-bar/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components:</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
     <style>
@@ -28,13 +27,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-action-bar</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-action-bar/readme.md"
-            >calcite-action-bar readme.</a
-          >
-        </p>
         <div class="flexxed">
           <section>
             <h2>LTR</h2>

--- a/src/demos/action-pad/basic.html
+++ b/src/demos/action-pad/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-action-pad</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,14 +14,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-action-pad</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-action-pad/readme.md"
-          >
-            calcite-action-pad readme.</a
-          >
-        </p>
 
         <div class="action-pad-container">
           <calcite-action-pad>

--- a/src/demos/action/add-action-icon-after-init.html
+++ b/src/demos/action/add-action-icon-after-init.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-action</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,12 +14,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-action</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-action/readme.md"
-            >calcite-action readme.</a
-          >
-        </p>
 
         <h2>LTR</h2>
         <div class="action-container">
@@ -30,15 +23,14 @@
           </calcite-action>
 
           <script>
-          var slotTestNode = document.getElementById("slot-test");
-          setTimeout(function(){
-            var div = document.createElement("div");
+            const slotTestNode = document.getElementById("slot-test");
+            setTimeout(function(){
+            const div = document.createElement("div");
             div.innerHTML = `<calcite-icon scale="s" icon="configure-popup"></calcite-icon>`;
             slotTestNode.appendChild(div);
           }, 2000)
           </script>
 
-          </div>
         </div>
       </section>
     </main>

--- a/src/demos/action/basic.html
+++ b/src/demos/action/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-action</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,12 +14,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-action</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-action/readme.md"
-            >calcite-action readme.</a
-          >
-        </p>
 
         <h2>LTR</h2>
         <div class="example-container">
@@ -36,7 +29,6 @@
             text-enabled
           >
             <calcite-icon icon="configure-popup" scale="s"></calcite-icon>
-          </calcite-action>
           </calcite-action>
 
           <h3>Clear</h3>

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Calcite App Components: calcite-block</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,12 +14,6 @@
       <section class="example-container">
         <h1>Block</h1>
 
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-block/readme.md"
-            >calcite-block readme.</a
-          >
-        </p>
         <h2>Default (non-collapsible)</h2>
 
         <calcite-block heading="Heading" summary="summary"></calcite-block>

--- a/src/demos/block/with-value-list.html
+++ b/src/demos/block/with-value-list.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Calcite App Components: calcite-block</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -14,12 +13,6 @@
     <main>
       <section class="example-container">
         <h1>Block</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-block/readme.md"
-            >calcite-block readme.</a
-          >
-        </p>
 
         <h2>Block with slotted Value List</h2>
         <calcite-block heading="All the king's buff horses couldn't fix the turbo." summary="summary" open collapsible>

--- a/src/demos/flow-item/basic.html
+++ b/src/demos/flow-item/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-flow-item</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,13 +14,7 @@
     <main>
       <section class="example-container">
         <h1>calcite-flow-item</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-flow-item/readme.md"
-            >calcite-flow-item readme.</a
-          >
-        </p>
+
         <div class="flow-container">
           <calcite-flow-item heading="What are the most popular commute alternatives?" summary="I don't know.">
             <div slot="menu-actions">

--- a/src/demos/flow/adding-items.html
+++ b/src/demos/flow/adding-items.html
@@ -6,18 +6,9 @@
 
     <title>Calcite App Components: calcite-flow</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
     <style>
-      .demo-block {
-        width: 100%;
-        height: 240px;
-        margin-bottom: 8px;
-        background-color: #fff;
-        border-radius: 3px;
-        box-shadow: 0 1px 0 #e0e0e0;
-      }
       .demo-btn {
         background-color: transparent;
         border: 1px solid #007ac2;
@@ -36,12 +27,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-flow</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-flow/readme.md"
-            >calcite-flow readme.</a
-          >
-        </p>
 
         <h2>Adding new Flow-items to Flow</h2>
         <calcite-flow id="flow">
@@ -60,42 +45,15 @@
           </calcite-flow-item>
         </calcite-flow>
         <button class="demo-btn" id="add-flow-item">Add Flow Item</button>
-
-        <details>
-          <summary>Sample JavaScript</summary>
-          <pre><code class="language-js">&lt;script&gt;
-  var flowNode = document.getElementById("flow");
-
-  var addFlowButtonNode = document.getElementById("add-flow-item");
-
-  addFlowButtonNode.addEventListener("click", function() {
-  var newNode = document.createElement("calcite-flow-item");
-  newNode.heading = "Item " + (flowNode.childElementCount + 1);
-  newNode.summary =  "I don't have an answer to this questions. Stop asking me this question."
-  newNode.innerHTML = `
-      &lt;p&gt;&lt;img src="https://via.placeholder.com/300x200" alt="placeholder" /&gt;&lt;/p>
-      &lt;p&gt;&lt;img src="https://via.placeholder.com/300x200" alt="placeholder" /&gt;&lt;/p&gt;
-      &lt;calcite-action slot="menu-actions"&gt;
-          &lt;calcite-icon icon="pencil" scale="s"&gt;&lt;/calcite-icon&gt;
-      &lt;/calcite-action&gt;
-      &lt;div slot="footer-actions"&gt;
-      &lt;button&gt;Save&lt;/button&gt;
-      &lt;button&gt;Cancel&lt;/button&gt;
-      &lt;/div&gt;
-  `;
-  flowNode.appendChild(newNode);
-  });
-&lt;/script&gt;</code></pre>
-        </details>
       </section>
     </main>
     <script>
-      var flowNode = document.getElementById("flow");
+      const flowNode = document.getElementById("flow");
 
-      var addFlowButtonNode = document.getElementById("add-flow-item");
+      const addFlowButtonNode = document.getElementById("add-flow-item");
 
       addFlowButtonNode.addEventListener("click", function() {
-        var newNode = document.createElement("calcite-flow-item");
+        const newNode = document.createElement("calcite-flow-item");
 
         newNode.beforeBack = function() {
           newNode.loading = true;
@@ -124,7 +82,7 @@
         `;
         flowNode.appendChild(newNode);
         setTimeout(function() {
-          var newDiv = document.createElement("div");
+          const newDiv = document.createElement("div");
           newDiv.innerHTML = "new div who dis?";
           newNode.appendChild(newDiv);
         }, 100);

--- a/src/demos/flow/basic.html
+++ b/src/demos/flow/basic.html
@@ -6,53 +6,14 @@
 
     <title>Calcite App Components: calcite-flow</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
-    <style>
-      .demo-block {
-        width: 100%;
-        height: 240px;
-        margin-bottom: 8px;
-        background-color: #fff;
-        border-radius: 3px;
-        box-shadow: 0 1px 0 #e0e0e0;
-      }
-      .demo-btn {
-        background-color: transparent;
-        border: 1px solid #007ac2;
-        color: #007ac2;
-        font-size: 1rem;
-        font-family: inherit;
-        padding: 0.7rem;
-        border-radius: 3px;
-        margin: 1rem 0.2rem;
-        min-width: 5rem;
-      }
-    </style>
   </head>
 
   <body>
     <main>
       <section class="example-container">
         <h1>calcite-flow</h1>
-        <p>
-          A Flow is a container for showing flow-items 1 at a time. This can be useful to break content into steps,
-          useful for complicated instructions or walkthroughs.
-        </p>
-        <p>
-          To go to a next step, you'll need to
-          <a href="advanced/flow-adding-items.html">add a new flow-item using native dom methods</a>. The back button
-          (used to go back to previous steps (flow-items) emits an event, but does not automatically switch flow-items
-          by default. Hook into the event to do any cleanup necessary then remove the last flow-item in the flow. Or use
-          the handle-back attribute to have it automatically remove the last flow-item.
-        </p>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-flow/readme.md"
-            >calcite-flow readme.</a
-          >
-        </p>
 
         <h2>Basic</h2>
         <calcite-flow>

--- a/src/demos/handle/basic.html
+++ b/src/demos/handle/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-handle</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
   </head>
 
@@ -14,12 +13,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-handle</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-handle/readme.md"
-            >calcite-handle readme.</a
-          >
-        </p>
 
         <calcite-handle></calcite-handle>
       </section>

--- a/src/demos/panel/basic.html
+++ b/src/demos/panel/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-panel</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,12 +14,7 @@
     <main>
       <section class="example-container">
         <h1>calcite-panel</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-panel/readme.md">
-            calcite-panel readme.</a
-          >
-        </p>
+
         <h2>Basic Panel</h2>
         <calcite-panel>
           <div slot="header-content">panel header</div>
@@ -49,7 +43,7 @@
         </calcite-panel>
 
         <script>
-          var dismissiblePanel = document.getElementById("dismissible-panel");
+          const dismissiblePanel = document.getElementById("dismissible-panel");
           dismissiblePanel.addEventListener("calcitePanelDismissedChange", function() {
             console.log("calcitePanelDismiss event");
           });

--- a/src/demos/pick-list/advanced.html
+++ b/src/demos/pick-list/advanced.html
@@ -16,12 +16,6 @@
   <body>
     <header>
       <h1>calcite-pick-list</h1>
-      <p>
-        see the
-        <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-pick-list/readme.md"
-          >calcite-pick-list readme.</a
-        >
-      </p>
 
       <style>
         calcite-pick-list {
@@ -156,7 +150,6 @@
           });
         </script>
 
-        <!-- <calcite-pick-list id="three" text-heading="Configuration Pick List - Draggable" mode="configuration" drag-enabled> -->
         <calcite-pick-list id="three">
           <calcite-pick-list-group text-group-title="numbers">
             <calcite-pick-list-item
@@ -302,7 +295,6 @@
             console.log(event.detail);
           });
         </script>
-        <!-- <calcite-pick-list id="three" text-label="Configuration Pick List - Draggable" mode="configuration" drag-enabled> -->
         <calcite-pick-list id="three_rtl">
           <calcite-pick-list-group text-group-title="numbers">
             <calcite-pick-list-item

--- a/src/demos/pick-list/basic.html
+++ b/src/demos/pick-list/basic.html
@@ -16,14 +16,7 @@
     <main>
       <section class="example-container">
         <h1>calcite-pick-list</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-pick-list/readme.md"
-            >calcite-pick-list readme.</a
-          >
-          <a href="calcite-pick-list-advanced.html">Advanced Pick List Demos</a>
-        </p>
+
         <h2>Pick List - Default</h2>
         <calcite-pick-list id="one">
           <calcite-pick-list-item text-label="T. Rex" text-description="arm strength impaired" value="trex">
@@ -144,7 +137,6 @@
           pickList3.addEventListener("calciteListChange", (event) => {
             console.log(event.detail);
           });
-        </script>
         </script>
 
         <h2>Pick List with sub-groups</h2>

--- a/src/demos/shell-panel/basic.html
+++ b/src/demos/shell-panel/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-shell-panel</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,16 +14,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-shell-panel</h1>
-        <p>The shell panel expands to fill the height of its container. If the container lacks a defined height, it will size
-          according to it's content height. It's intended purpose is to be slotted into a calcite-shell as the leading or trailing panel.</p>
-        </p>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell-panel/readme.md"
-            >calcite-shell-panel readme.</a
-          >
-        </p>
 
         <h2>Basic Shell Panel</h2>
         <calcite-shell-panel>

--- a/src/demos/shell/basic.html
+++ b/src/demos/shell/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-shell</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
 
@@ -25,20 +24,6 @@
     <main>
       <div class="example-container">
         <h1>calcite-shell</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell/readme.md"
-            >calcite-shell readme.</a
-          >
-        </p>
-        <p>
-          <em
-            >The shell is absolutely positioned and sized to fill its container. In normal application it might fill up
-            the entire viewport. For demo purposes, it's inside a relatively positioned container sized to fit in this
-            area. <a href="/demos/advanced/shell-demo-app-full-window.html">See the full-window demo.</a></em
-          >
-        </p>
-        <p><em>Please note: calcite-shell supports tablet as the smallest screen size.</em></p>
 
         <h2>Basic Shell</h2>
         <div class="shell-container">
@@ -86,10 +71,7 @@
           </calcite-shell>
         </div>
 
-        <!-- <h2>Dark Theme</h2> -->
-        <!-- <calcite-shell theme="dark"></calcite-shell> -->
       </div>
-      <p style="text-align: center;">Box Shadow added to show app edges.</p>
     </main>
   </body>
 </html>

--- a/src/demos/shell/demo-app-full-window-reversed.html
+++ b/src/demos/shell/demo-app-full-window-reversed.html
@@ -69,64 +69,38 @@
             <calcite-action-pad id="action-pad" placement="side" slot="action-pad" hidden>
               <calcite-action-group>
                 <calcite-action text="Add">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
-                    <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
-                  </svg>
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
                 </calcite-action>
               </calcite-action-group>
             </calcite-action-pad>
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
                 <calcite-action text="Add">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
-                  </svg>
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Save" disabled>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M14 1H2a1 1 0 0 0-1 1v10a.99.99 0 0 0 .293.707l2 2A.995.995 0 0 0 4 15h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 14v-3h2v3zm6-.001V14h-1v-4H5v4H4v-4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1zM12 6H4V2h8z"
-                    />
-                  </svg>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Layers" active indicator>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M15.71 11.487l-7.4 4.441a.738.738 0 0 1-.635 0L.27 11.487a.272.272 0 0 1 0-.508l.913-.547 6.49 3.895a.738.738 0 0 0 .635 0l6.49-3.895.912.547a.271.271 0 0 1 0 .508zm0-3.74L14.8 7.2l-6.49 3.894a.738.738 0 0 1-.635 0L1.184 7.2l-.913.547a.272.272 0 0 0 0 .507l7.403 4.442a.738.738 0 0 0 .635 0l7.402-4.442a.271.271 0 0 0 0-.507zM.272 5.022l7.403 4.441a.738.738 0 0 0 .635 0l7.402-4.441a.271.271 0 0 0 0-.508L8.309.073a.738.738 0 0 0-.635 0L.27 4.514a.272.272 0 0 0 0 .508z"
-                    />
-                  </svg>
+                  <calcite-icon icon="layers" scale="s"></calcite-icon>
                 </calcite-action>
               </calcite-action-group>
               <calcite-action-group>
                 <calcite-action text="An unbelievably long title">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
-                  </svg>
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Save" disabled>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M14 1H2a1 1 0 0 0-1 1v10a.99.99 0 0 0 .293.707l2 2A.995.995 0 0 0 4 15h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 14v-3h2v3zm6-.001V14h-1v-4H5v4H4v-4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1zM12 6H4V2h8z"
-                    />
-                  </svg>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Layers" indicator>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M15.71 11.487l-7.4 4.441a.738.738 0 0 1-.635 0L.27 11.487a.272.272 0 0 1 0-.508l.913-.547 6.49 3.895a.738.738 0 0 0 .635 0l6.49-3.895.912.547a.271.271 0 0 1 0 .508zm0-3.74L14.8 7.2l-6.49 3.894a.738.738 0 0 1-.635 0L1.184 7.2l-.913.547a.272.272 0 0 0 0 .507l7.403 4.442a.738.738 0 0 0 .635 0l7.402-4.442a.271.271 0 0 0 0-.507zM.272 5.022l7.403 4.441a.738.738 0 0 0 .635 0l7.402-4.441a.271.271 0 0 0 0-.508L8.309.073a.738.738 0 0 0-.635 0L.27 4.514a.272.272 0 0 0 0 .508z"
-                    />
-                  </svg>
+                  <calcite-icon icon="layers" scale="s"></calcite-icon>
                 </calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
               <calcite-block collapsible  heading="Primary Content" summary="This is the primary.">
                 <calcite-block-content>
                   <calcite-action text="Side ActionPad" text-enabled id="action-pad-button" indicator>
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                      <path
-                        d="M13.071 1H1.93a.929.929 0 0 0-.93.929V13.07a.929.929 0 0 0 .929.929H13.07a.929.929 0 0 0 .929-.929V1.93a.929.929 0 0 0-.928-.93zM13 13H2V2h11zm-7-1V3l4.5 4.5zm1-2.414L9.086 7.5 7 5.414z"
-                      />
-                    </svg>
+                    <calcite-icon icon="caret-square-right" scale="s"></calcite-icon>
                   </calcite-action>
                   <!-- popover from click of this action at bottom of file -->
                   <calcite-action
@@ -134,18 +108,14 @@
                     text-enabled
                     id="shell-floating-panel-button"
                   >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                      <path d="M2 14h4v1H1v-5h1zm12-8h1V1h-5v1h4zm0 4v4h-4v1h5v-5zM1 6h1V2h4V1H1z" />
-                    </svg>
+                    <calcite-icon icon="extent" scale="s"></calcite-icon>
                   </calcite-action>
                   <calcite-action
                     text="Over Shell Floating Panel"
                     text-enabled
                     id="shell-floating-panel-over-button"
                   >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                      <path d="M2.647 12.584L12.288 3H9V2h5v5h-1V3.702l-9.647 9.591z" />
-                    </svg>
+                    <calcite-icon icon="arrow-up-right" scale="s"></calcite-icon>
                   </calcite-action>
                 </calcite-block-content>
               </calcite-block>
@@ -179,51 +149,29 @@
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Add" active>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
-                  </svg>
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Save" disabled>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M14 1H2a1 1 0 0 0-1 1v10a.99.99 0 0 0 .293.707l2 2A.995.995 0 0 0 4 15h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 14v-3h2v3zm6-.001V14h-1v-4H5v4H4v-4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1zM12 6H4V2h8z"
-                    />
-                  </svg>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Layers">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M15.71 11.487l-7.4 4.441a.738.738 0 0 1-.635 0L.27 11.487a.272.272 0 0 1 0-.508l.913-.547 6.49 3.895a.738.738 0 0 0 .635 0l6.49-3.895.912.547a.271.271 0 0 1 0 .508zm0-3.74L14.8 7.2l-6.49 3.894a.738.738 0 0 1-.635 0L1.184 7.2l-.913.547a.272.272 0 0 0 0 .507l7.403 4.442a.738.738 0 0 0 .635 0l7.402-4.442a.271.271 0 0 0 0-.507zM.272 5.022l7.403 4.441a.738.738 0 0 0 .635 0l7.402-4.441a.271.271 0 0 0 0-.508L8.309.073a.738.738 0 0 0-.635 0L.27 4.514a.272.272 0 0 0 0 .508z"
-                    />
-                  </svg>
+                  <calcite-icon icon="layers" scale="s"></calcite-icon>
                 </calcite-action>
               </calcite-action-group>
               <calcite-action-group>
                 <calcite-action text="An unbelievably long title">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path d="M9 7h5v2H9v5H7V9H2V7h5V2h2z" />
-                  </svg>
+                  <calcite-icon icon="plus" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Save" disabled>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M14 1H2a1 1 0 0 0-1 1v10a.99.99 0 0 0 .293.707l2 2A.995.995 0 0 0 4 15h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM6 14v-3h2v3zm6-.001V14h-1v-4H5v4H4v-4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1zM12 6H4V2h8z"
-                    />
-                  </svg>
+                  <calcite-icon icon="save" scale="s"></calcite-icon>
                 </calcite-action>
                 <calcite-action text="Layers">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                    <path
-                      d="M15.71 11.487l-7.4 4.441a.738.738 0 0 1-.635 0L.27 11.487a.272.272 0 0 1 0-.508l.913-.547 6.49 3.895a.738.738 0 0 0 .635 0l6.49-3.895.912.547a.271.271 0 0 1 0 .508zm0-3.74L14.8 7.2l-6.49 3.894a.738.738 0 0 1-.635 0L1.184 7.2l-.913.547a.272.272 0 0 0 0 .507l7.403 4.442a.738.738 0 0 0 .635 0l7.402-4.442a.271.271 0 0 0 0-.507zM.272 5.022l7.403 4.441a.738.738 0 0 0 .635 0l7.402-4.441a.271.271 0 0 0 0-.508L8.309.073a.738.738 0 0 0-.635 0L.27 4.514a.272.272 0 0 0 0 .508z"
-                    />
-                  </svg>
+                  <calcite-icon icon="layers" scale="s"></calcite-icon>
                 </calcite-action>
               </calcite-action-group>
               <calcite-action-group slot="bottom-actions">
                   <calcite-action text="Tips" id="tip-manager-button">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%">
-                        <path d="M10.495 1.179a4.5 4.5 0 0 0-5.99 0 4.49 4.49 0 0 0-1.455 3.72 6.342 6.342 0 0 0 1.38 3.574 3.174 3.174 0 0 1 .426.657A5.66 5.66 0 0 1 5 10v1l.277 1.5L5 13.715l1.4.966a2.02 2.02 0 0 0 2.2 0l1.4-.966-.277-1.215L10 11v-1a5.66 5.66 0 0 1 .145-.87 3.174 3.174 0 0 1 .426-.656 6.342 6.342 0 0 0 1.379-3.576 4.49 4.49 0 0 0-1.455-3.72zM9 13.475l-.868.61a1.1 1.1 0 0 1-1.264 0L6 13.474V12h3zm.769-5.631a3.32 3.32 0 0 0-.585.98 4.716 4.716 0 0 0-.171 1.118C8.993 10.266 9 11.02 9 11.02H8V8H7v3.02H6s.007-.754-.013-1.078a4.716 4.716 0 0 0-.17-1.118 3.32 3.32 0 0 0-.586-.98 5.377 5.377 0 0 1-1.283-3.037 3.7 3.7 0 0 1 1.119-3.01 3.757 3.757 0 0 1 4.866 0 3.7 3.7 0 0 1 1.119 3.01 5.377 5.377 0 0 1-1.283 3.037zM9 6v1H6V6z"/>
-                      </svg>
+                    <calcite-icon icon="lightbulb" scale="s"></calcite-icon>
                     </calcite-action>
               </calcite-action-group>
             </calcite-action-bar>
@@ -248,11 +196,7 @@
                           label="click-me"
                           onClick="console.log('clicked');"
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                            <path
-                              d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                            />
-                          </svg>
+                          <calcite-icon icon="x" scale="s"></calcite-icon>
                         </calcite-action>
                       </calcite-value-list-item>
                       <calcite-value-list-item
@@ -266,11 +210,7 @@
                           label="click-me"
                           onClick="console.log('clicked');"
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                            <path
-                              d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                            />
-                          </svg>
+                          <calcite-icon icon="x" scale="s"></calcite-icon>
                         </calcite-action>
                       </calcite-value-list-item>
                       <calcite-value-list-item
@@ -284,11 +224,7 @@
                           label="click-me"
                           onClick="console.log('clicked');"
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                            <path
-                              d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                            />
-                          </svg>
+                          <calcite-icon icon="x" scale="s"></calcite-icon>
                         </calcite-action>
                       </calcite-value-list-item>
                     </calcite-value-list>
@@ -322,11 +258,7 @@
                       label="click-me"
                       onClick="console.log('clicked');"
                     >
-                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                        <path
-                          d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                        />
-                      </svg>
+                      <calcite-icon icon="x" scale="s"></calcite-icon>
                     </calcite-action>
                   </calcite-value-list-item>
                   <calcite-value-list-item
@@ -340,11 +272,7 @@
                       label="click-me"
                       onClick="console.log('clicked');"
                     >
-                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                        <path
-                          d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                        />
-                      </svg>
+                      <calcite-icon icon="x" scale="s"></calcite-icon>
                     </calcite-action>
                   </calcite-value-list-item>
                   <calcite-value-list-item
@@ -358,11 +286,7 @@
                       label="click-me"
                       onClick="console.log('clicked');"
                     >
-                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                        <path
-                          d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                        />
-                      </svg>
+                      <calcite-icon icon="x" scale="s"></calcite-icon>
                     </calcite-action>
                   </calcite-value-list-item>
                 </calcite-value-list>
@@ -380,11 +304,7 @@
                           label="click-me"
                           onClick="console.log('clicked');"
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                            <path
-                              d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                            />
-                          </svg>
+                          <calcite-icon icon="x" scale="s"></calcite-icon>
                         </calcite-action>
                       </calcite-value-list-item>
                       <calcite-value-list-item
@@ -398,11 +318,7 @@
                           label="click-me"
                           onClick="console.log('clicked');"
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                            <path
-                              d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                            />
-                          </svg>
+                          <calcite-icon icon="x" scale="s"></calcite-icon>
                         </calcite-action>
                       </calcite-value-list-item>
                       <calcite-value-list-item
@@ -416,11 +332,7 @@
                           label="click-me"
                           onClick="console.log('clicked');"
                         >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-                            <path
-                              d="M8.718 8l5.303 5.303-.707.707L8.01 8.707 2.707 14.01 2 13.303 7.303 8 2 2.697l.707-.707L8.01 7.293l5.304-5.303.707.707z"
-                            />
-                          </svg>
+                          <calcite-icon icon="x" scale="s"></calcite-icon>
                         </calcite-action>
                       </calcite-value-list-item>
                     </calcite-value-list>
@@ -520,7 +432,7 @@
           <h3 class="heading" slot="header-content">WE CARE A LOT</h3>
           <calcite-pick-list filter-enabled filter-sticky>
             <calcite-action slot="menu-actions" label="options">
-                <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" fill="currentColor" viewBox="0 0 16 16"><path d="M14 9.05A1.05 1.05 0 1 1 15.05 8 1.05 1.05 0 0 1 14 9.05zm-6 0A1.05 1.05 0 1 1 9.05 8 1.05 1.05 0 0 1 8 9.05zm-6 0A1.05 1.05 0 1 1 3.05 8 1.05 1.05 0 0 1 2 9.05z"></path></svg>
+              <calcite-icon icon="ellipsis" scale="s"></calcite-icon>
             </calcite-action>
             <calcite-pick-list-item text-label="about disasters, fires, floods and killer bees" value="1"></calcite-pick-list-item>
             <calcite-pick-list-item text-label="about the NASA shuttle falling in the sea" value="2"></calcite-pick-list-item>

--- a/src/demos/shell/demo-app-full-window-reversed.html
+++ b/src/demos/shell/demo-app-full-window-reversed.html
@@ -6,14 +6,13 @@
 
     <title>Calcite App Components: calcite-shell</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
 
     <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/themes/light/main.css" />
     <script src="https://js.arcgis.com/4.12/"></script>
     <style>
       html, body, main, .shell-container {
-        position:relative;
+        position: relative;
         width: 100%;
         height: 100%;
       }
@@ -29,11 +28,11 @@
 
     <script>
       require(["esri/Map", "esri/views/MapView"], function(Map, MapView) {
-        var map = new Map({
+        const map = new Map({
           basemap: "gray-vector"
         });
 
-        var view = new MapView({
+        const view = new MapView({
           container: "viewDiv",
           map: map,
           zoom: 8,
@@ -452,7 +451,7 @@
                   </calcite-block-content>
                 </calcite-block>
                 <calcite-button slot="footer-actions" width="half">Save</calcite-button>
-                <calcite-button slot="footer-actions" width="half" appearance="clear">Cancel</button>
+                <calcite-button slot="footer-actions" width="half" appearance="clear">Cancel</calcite-button>
               </calcite-flow-item>
             </calcite-flow>
           </calcite-shell-panel>
@@ -534,22 +533,22 @@
       </calcite-popover>
       <script>
 
-        var tipManagerButton = document.getElementById("tip-manager-button");
-        var tipManager = document.getElementById("tip-manager");
+        const tipManagerButton = document.getElementById("tip-manager-button");
+        const tipManager = document.getElementById("tip-manager");
         tipManagerButton.addEventListener("click", function(){
           tipManager.hasAttribute("hidden") ? tipManager.removeAttribute("hidden") : tipManager.setAttribute("hidden", "");
         });
 
-        var actionPad = document.getElementById("action-pad");
-        var actionPadButton = document.getElementById("action-pad-button");
+        const actionPad = document.getElementById("action-pad");
+        const actionPadButton = document.getElementById("action-pad-button");
         actionPadButton.addEventListener("click", function() {
           actionPad.hasAttribute("hidden") ? actionPad.removeAttribute("hidden") : actionPad.setAttribute("hidden", "");
 
           actionPad.positionElement = actionPadButton;
         });
 
-        var shellFloatingPanel = document.getElementById("shell-floating-panel");
-        var shellFloatingPanelButton = document.getElementById("shell-floating-panel-button");
+        const shellFloatingPanel = document.getElementById("shell-floating-panel");
+        const shellFloatingPanelButton = document.getElementById("shell-floating-panel-button");
         shellFloatingPanelButton.addEventListener("click", function() {
           shellFloatingPanel.hasAttribute("hidden")
             ? shellFloatingPanel.removeAttribute("hidden")
@@ -558,8 +557,8 @@
           shellFloatingPanel.positionElement = shellFloatingPanelButton;
         });
 
-        var shellFloatingPanelOver = document.getElementById("shell-floating-panel-over");
-        var shellFloatingPanelOverButton = document.getElementById("shell-floating-panel-over-button");
+        const shellFloatingPanelOver = document.getElementById("shell-floating-panel-over");
+        const shellFloatingPanelOverButton = document.getElementById("shell-floating-panel-over-button");
         shellFloatingPanelOverButton.addEventListener("click", function() {
           shellFloatingPanelOver.hasAttribute("hidden")
             ? shellFloatingPanelOver.removeAttribute("hidden")
@@ -568,7 +567,7 @@
           shellFloatingPanelOver.positionElement = shellFloatingPanelOverButton;
         });
 
-        var flowNode = document.getElementById("flow");
+        const flowNode = document.getElementById("flow");
       </script>
     </main>
   </body>

--- a/src/demos/shell/demo-app-full-window.html
+++ b/src/demos/shell/demo-app-full-window.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-shell</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
 
     <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/themes/light/main.css" />
@@ -32,11 +31,11 @@
 
     <script>
       require(["esri/Map", "esri/views/MapView"], function(Map, MapView) {
-        var map = new Map({
+        const map = new Map({
           basemap: "gray-vector"
         });
 
-        var view = new MapView({
+        const view = new MapView({
           container: "viewDiv",
           map: map,
           zoom: 8,
@@ -456,24 +455,24 @@
         </calcite-panel>
       </calcite-popover>
       <script>
-        var tipManagerButton = document.getElementById("tip-manager-button");
-        var tipManager = document.getElementById("tip-manager");
+        const tipManagerButton = document.getElementById("tip-manager-button");
+        const tipManager = document.getElementById("tip-manager");
         tipManagerButton.addEventListener("click", function() {
           tipManager.hasAttribute("hidden")
             ? tipManager.removeAttribute("hidden")
             : tipManager.setAttribute("hidden", "");
         });
 
-        var actionPad = document.getElementById("action-pad");
-        var actionPadButton = document.getElementById("action-pad-button");
+        const actionPad = document.getElementById("action-pad");
+        const actionPadButton = document.getElementById("action-pad-button");
         actionPadButton.addEventListener("click", function() {
           actionPad.hasAttribute("hidden") ? actionPad.removeAttribute("hidden") : actionPad.setAttribute("hidden", "");
 
           actionPad.positionElement = actionPadButton;
         });
 
-        var shellFloatingPanel = document.getElementById("shell-floating-panel");
-        var shellFloatingPanelButton = document.getElementById("shell-floating-panel-button");
+        const shellFloatingPanel = document.getElementById("shell-floating-panel");
+        const shellFloatingPanelButton = document.getElementById("shell-floating-panel-button");
         shellFloatingPanelButton.addEventListener("click", function() {
           shellFloatingPanel.hasAttribute("hidden")
             ? shellFloatingPanel.removeAttribute("hidden")
@@ -482,8 +481,8 @@
           shellFloatingPanel.positionElement = shellFloatingPanelButton;
         });
 
-        var shellFloatingPanelOver = document.getElementById("shell-floating-panel-over");
-        var shellFloatingPanelOverButton = document.getElementById("shell-floating-panel-over-button");
+        const shellFloatingPanelOver = document.getElementById("shell-floating-panel-over");
+        const shellFloatingPanelOverButton = document.getElementById("shell-floating-panel-over-button");
         shellFloatingPanelOverButton.addEventListener("click", function() {
           shellFloatingPanelOver.hasAttribute("hidden")
             ? shellFloatingPanelOver.removeAttribute("hidden")
@@ -492,7 +491,7 @@
           shellFloatingPanelOver.positionElement = shellFloatingPanelOverButton;
         });
 
-        var flowNode = document.getElementById("flow");
+        const flowNode = document.getElementById("flow");
       </script>
     </main>
   </body>

--- a/src/demos/shell/demo-app-rtl.html
+++ b/src/demos/shell/demo-app-rtl.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-shell</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
 
@@ -25,22 +24,6 @@
     <main>
       <div class="example-container">
         <h1>calcite-shell</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell/readme.md"
-            >calcite-shell readme.</a
-          >
-        </p>
-
-        <p>
-          <em
-            >The shell is absolutely positioned and sized to fill its container. In normal application it might fill up
-            the entire viewport. For demo purposes, it's inside a relatively positioned container sized to fit in this
-            area.</em
-          >
-          <a href="/demos/advanced/shell-demo-app-full-window.html">See the full-window demo.</a>
-        </p>
-        <p><em>Please note: calcite-shell supports tablet as the smallest screen size.</em></p>
 
         <style>
           #viewDiv,
@@ -54,18 +37,18 @@
 
         <script>
           require(["esri/Map", "esri/views/MapView"], function(Map, MapView) {
-            var map = new Map({
+            const map = new Map({
               basemap: "streets"
             });
 
-            var view = new MapView({
+            const view = new MapView({
               container: "viewDiv",
               map: map,
               zoom: 4,
               center: [15, 65]
             });
 
-            var view2 = new MapView({
+            const view2 = new MapView({
               container: "viewDiv2",
               map: map,
               zoom: 4,
@@ -239,7 +222,6 @@
                 <h2 class="heading">My App</h2>
               </header>
             </div>
-            <!-- <calcite-tip-manager slot="tip-manager" /> -->
             <div id="viewDiv"></div>
 
             <footer slot="shell-footer">Footer</footer>
@@ -415,14 +397,12 @@
                 <h2 class="heading">My App</h2>
               </header>
             </div>
-            <!-- <calcite-tip-manager slot="tip-manager" /> -->
             <div id="viewDiv2"></div>
 
             <footer slot="shell-footer">Footer</footer>
           </calcite-shell>
         </div>
       </div>
-      <p style="text-align: center;">Box Shadow added to show app edges.</p>
     </main>
   </body>
 </html>

--- a/src/demos/shell/demo-app.html
+++ b/src/demos/shell/demo-app.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-shell</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
 
@@ -25,20 +24,6 @@
     <main>
       <div class="example-container">
         <h1>calcite-shell</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell/readme.md"
-            >calcite-shell readme.</a
-          >
-        </p>
-        <p>
-          <em
-            >The shell is absolutely positioned and sized to fill its container. In normal application it might fill up
-            the entire viewport. For demo purposes, it's inside a relatively positioned container sized to fit in this
-            area. <a href="/demos/advanced/shell-demo-app-full-window.html">See the full-window demo.</a></em
-          >
-        </p>
-        <p><em>Please note: calcite-shell supports tablet as the smallest screen size.</em></p>
 
         <style>
           #viewDiv,
@@ -52,18 +37,18 @@
 
         <script>
           require(["esri/Map", "esri/views/MapView"], function(Map, MapView) {
-            var map = new Map({
+            const map = new Map({
               basemap: "streets"
             });
 
-            var view = new MapView({
+            const view = new MapView({
               container: "viewDiv",
               map: map,
               zoom: 4,
               center: [15, 65]
             });
 
-            var view2 = new MapView({
+            const view2 = new MapView({
               container: "viewDiv2",
               map: map,
               zoom: 4,
@@ -463,14 +448,12 @@
                 <h2 class="heading">My App</h2>
               </header>
             </div>
-            <!-- <calcite-tip-manager slot="tip-manager" /> -->
             <div id="viewDiv2"></div>
 
             <footer slot="shell-footer">Footer</footer>
           </calcite-shell>
         </div>
       </div>
-      <p style="text-align: center;">Box Shadow added to show app edges.</p>
     </main>
   </body>
 </html>

--- a/src/demos/shell/panel-with-action-bar.html
+++ b/src/demos/shell/panel-with-action-bar.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-shell-panel</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -15,15 +14,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-shell-panel</h1>
-        <p>The calcite-action-bar component is a great use for the action-bar slot in calcite-shell-panel.</p>
-        </p>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-shell-panel/readme.md"
-            >calcite-shell-panel readme.</a
-          >
-        </p>
 
         <h2>Basic Shell Panel</h2>
         <calcite-shell-panel slot="primary-panel" position="start">

--- a/src/demos/sortable-list/basic.html
+++ b/src/demos/sortable-list/basic.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-sortable-list</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
   </head>
 

--- a/src/demos/sortable-list/sortable-blocks.html
+++ b/src/demos/sortable-list/sortable-blocks.html
@@ -6,7 +6,6 @@
 
     <title>Calcite App Components: calcite-sortable-list</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
   </head>
 

--- a/src/demos/tip-manager/basic.html
+++ b/src/demos/tip-manager/basic.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Calcite App Components: calcite-tip-manager</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -14,13 +13,7 @@
     <main>
       <section class="example-container">
         <h1>Tip Manager</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-tip-manager/readme.md"
-            >calcite-tip-manager readme.</a
-          >
-        </p>
+
         <calcite-tip-manager>
           <calcite-tip-group text-group-title="Astronomy">
             <calcite-tip heading="The Red Rocks and Blue Water">
@@ -80,7 +73,7 @@
           document.getElementById("add").addEventListener("click", () => {
             const mgr = document.querySelector("calcite-tip-manager");
             const tips = mgr.querySelectorAll("calcite-tip");
-            newTip = tips[tips.length - 1].cloneNode(true);
+            const newTip = tips[tips.length - 1].cloneNode(true);
             mgr.appendChild(newTip);
           });
           document.getElementById("remove").addEventListener("click", () => {

--- a/src/demos/tip/basic.html
+++ b/src/demos/tip/basic.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Calcite App Components: calcite-tip</title>
 
-    <!-- Loads the link and script tags-->
     <script src="../_assets/head.js"></script>
     <script src="../_assets/toggles.js"></script>
   </head>
@@ -14,12 +13,7 @@
     <main>
       <section class="example-container">
         <h1>Tip</h1>
-        <p>
-          see the
-          <a href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-tip/readme.md"
-            >calcite-tip readme.</a
-          >
-        </p>
+
         <h2>With thumbnail</h2>
         <div>
           <calcite-tip heading="Celestial Bodies!">
@@ -53,7 +47,7 @@
           <calcite-tip>
             <img slot="thumbnail" src="https://placeimg.com/1000/600" alt="This is an image of nature." />
             <p>
-              This tip is how a tip should appar without a dismissible button as well as without a heading.
+              This tip is how a tip should appear without a dismissible button as well as without a heading.
             </p>
             <p>
               This is another paragraph in a subsequent "info" slot.
@@ -66,7 +60,7 @@
           <calcite-tip non-dismissible>
             <img slot="thumbnail" src="https://placeimg.com/1000/600" alt="This is an image of nature." />
             <p>
-              This tip is how a tip should appar without a dismissible button as well as without a heading.
+              This tip is how a tip should appear without a dismissible button as well as without a heading.
             </p>
             <p>
               This is another paragraph in a subsequent "info" slot.

--- a/src/demos/value-list/advanced.html
+++ b/src/demos/value-list/advanced.html
@@ -11,13 +11,6 @@
     <main>
       <section class="example-container" style="width: 28vw; margin-top: 2em;">
         <h1>calcite-value-list</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-value-list/readme.md"
-            >calcite-value-list readme.</a
-          >
-        </p>
 
         <style>
           .toggles {
@@ -194,7 +187,7 @@
       function toggleProperty(property) {
         const blocks = document.getElementsByTagName("calcite-value-list");
 
-        for (i = 0; i < blocks.length; i++) {
+        for (let i = 0; i < blocks.length; i++) {
           blocks[i].hasAttribute(property) ? blocks[i].removeAttribute(property) : blocks[i].setAttribute(property, "");
         }
       }

--- a/src/demos/value-list/basic.html
+++ b/src/demos/value-list/basic.html
@@ -11,13 +11,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-value-list</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-value-list/readme.md"
-            >calcite-value-list readme.</a
-          >
-        </p>
 
         <h3>multiple</h3>
         <calcite-value-list id="one" multiple="true" filter-enabled>

--- a/src/demos/value-list/double-action.html
+++ b/src/demos/value-list/double-action.html
@@ -11,13 +11,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-value-list</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-value-list/readme.md"
-            >calcite-value-list readme.</a
-          >
-        </p>
 
         <h3>multiple</h3>
         <calcite-value-list id="one" multiple="true" filter-enabled>

--- a/src/demos/value-list/value-update.html
+++ b/src/demos/value-list/value-update.html
@@ -11,13 +11,6 @@
     <main>
       <section class="example-container">
         <h1>calcite-value-list</h1>
-        <p>
-          see the
-          <a
-            href="https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-value-list/readme.md"
-            >calcite-value-list readme.</a
-          >
-        </p>
 
         <h3>multiple</h3>
         <calcite-value-list id="one">
@@ -46,7 +39,7 @@
         </calcite-value-list>
         <button id="click">Click</button>
         <script>
-          document.querySelector("#click").addEventListener("click", (event) => {
+          document.querySelector("#click").addEventListener("click", () => {
             const valueList = document.querySelector("#one");
             valueList.querySelector("calcite-value-list-item").value = "not dogs";
           });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Addresses: 

* Inconsistent test page casing.
* Invalid HTML syntax.
* Unused vars.
* Global vars.
* Commented-out markup.
* Unused CSS classes.
* Unnecessary doc content (superseded by stories).
* Typos.