### PR TITLE
chore(docs): migrate Storybook setup to latest

### DIFF
--- a/.storybook/addons.ts
+++ b/.storybook/addons.ts
@@ -1,4 +1,0 @@
-// tslint:disable:no-import-side-effect
-import "@storybook/addon-backgrounds/register";
-import "@storybook/addon-knobs/register";
-import "@storybook/addon-notes/register-panel";

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,9 @@
+module.exports = {
+  addons: [
+    "@storybook/addon-backgrounds/register",
+    "@storybook/addon-knobs/register",
+    "@storybook/addon-notes/register-panel"
+  ],
+  presets: ["@storybook/addon-docs/preset"],
+  stories: ["../src/**/*.stories.(mdx|ts)"]
+};

--- a/.storybook/presets.ts
+++ b/.storybook/presets.ts
@@ -1,1 +1,0 @@
-module.exports = ["@storybook/addon-docs/html/preset"];

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,4 @@
-import { addDecorator, addParameters, configure } from "@storybook/html";
+import { addDecorator, addParameters } from "@storybook/html";
 import centered from "@storybook/addon-centered/html";
 import theme from "./theme";
 
@@ -15,5 +15,3 @@ addParameters({
     }
   }
 });
-
-configure(require.context("../src", true, /\.stories\.(ts|mdx)$/), module);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This updates our Storybook setup to what the latest doc suggests (namely: using `main.ts` + `preview.ts` and no longer using environment-specific presets).
