### PR TITLE
docs: fix broken storybook build

### DIFF
--- a/docs/iframe.html
+++ b/docs/iframe.html
@@ -68,7 +68,7 @@
   } catch (e) {
     // eslint-disable-next-line no-console
     console.warn('unable to connect to top frame for connecting dev tools');
-  }</script><link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css"><link rel="stylesheet" href="build/calcite-app.css"><script src="build/calcite-app.esm.js"></script><script nomodule="" src="build/calcite-app.js"></script><link rel="stylesheet" href="vendor/@esri/calcite-components/calcite.css"><script src="vendor/@esri/calcite-components/calcite.esm.js"></script><script nomodule="" src="vendor/@esri/calcite-components/calcite.js"></script><style>/* centered decorator zoom fix - https://github.com/storybookjs/storybook/issues/7167#issuecomment-510876389 */
+  }</script><link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css"><link rel="stylesheet" href="build/calcite-app.css"><script type="module" src="build/calcite-app.esm.js"></script><script nomodule="" src="build/calcite-app.js"></script><link rel="stylesheet" href="vendor/@esri/calcite-components/calcite.css"><script type="module" src="vendor/@esri/calcite-components/calcite.esm.js"></script><script nomodule="" src="vendor/@esri/calcite-components/calcite.js"></script><style>/* centered decorator zoom fix - https://github.com/storybookjs/storybook/issues/7167#issuecomment-510876389 */
   html,
   body {
     width: 100%;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This is a manual fix for https://github.com/storybookjs/storybook/issues/9900, which strips out the ` type="module"` from the component script tags.

Note that this only affects the storybook distributable, not the preview.