### PR TITLE
fix(Action): Allow SVGs to be slotted into the calcite-action.

### DIFF
--- a/src/components/calcite-action/calcite-action.e2e.ts
+++ b/src/components/calcite-action/calcite-action.e2e.ts
@@ -26,9 +26,17 @@ describe("calcite-action", () => {
     expect(isVisible).toBe(false);
   });
 
-  it("should have icon container", async () => {
+  it("should have icon container with calcite-icon", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-action><calcite-icon icon="hamburger" scale="s"></calcite-icon></calcite-action>`);
+
+    const iconContainer = await page.find("calcite-action >>> .icon-container");
+    expect(iconContainer).not.toBeNull();
+  });
+
+  it("should have icon container with svg", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-action><svg></svg></calcite-icon></calcite-action>`);
 
     const iconContainer = await page.find("calcite-action >>> .icon-container");
     expect(iconContainer).not.toBeNull();

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -136,7 +136,7 @@ export class CalciteAction {
 
     const iconNode = loading
       ? calciteLoaderNode
-      : this.el.querySelector("calcite-icon")
+      : this.el.querySelector("calcite-icon,svg")
       ? slotContainerNode
       : null;
 

--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -136,7 +136,7 @@ export class CalciteAction {
 
     const iconNode = loading
       ? calciteLoaderNode
-      : this.el.querySelector("calcite-icon,svg")
+      : this.el.querySelector("calcite-icon, svg")
       ? slotContainerNode
       : null;
 

--- a/src/demos/action/basic.html
+++ b/src/demos/action/basic.html
@@ -22,31 +22,33 @@
             <calcite-icon icon="configure-popup" scale="s"></calcite-icon>
           </calcite-action>
 
-
-          <calcite-action
-            style="position: -webkit-sticky; position: sticky; top: 0;"
-            text="Sticky"
-            text-enabled
-          >
+          <calcite-action style="position: -webkit-sticky; position: sticky; top: 0;" text="Sticky" text-enabled>
             <calcite-icon icon="configure-popup" scale="s"></calcite-icon>
+          </calcite-action>
+
+          <h3>With SVG</h3>
+          <calcite-action indicator active text="click-me" label="hello world" text-enabled>
+            <svg
+              class=""
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              height="16"
+              width="16"
+              viewBox="0 0 16 16"
+            >
+              <path
+                d="M15.065 14.286L10 5V1.214A.214.214 0 0 1 10.214 1h.572A.214.214 0 0 0 11 .786V.214A.214.214 0 0 0 10.786 0H5.214A.214.214 0 0 0 5 .214v.572A.214.214 0 0 0 5.214 1h.572A.214.214 0 0 1 6 1.214V5L.935 14.286A1.159 1.159 0 0 0 1.952 16h12.096a1.159 1.159 0 0 0 1.017-1.714zm-.88.636a.158.158 0 0 1-.137.078H1.952a.158.158 0 0 1-.137-.079.161.161 0 0 1-.003-.157L7 5.255V1h2v1H8v1h1v2H8v1h1.406l1.091 2H8v1h3.043l3.144 5.765a.16.16 0 0 1-.002.157zM5.005 11l-1.637 3h9.263l-1.637-3zm.048 2l.546-1H10.4l.546 1z"
+              ></path>
+            </svg>
           </calcite-action>
 
           <h3>Clear</h3>
 
-          <calcite-action
-            text="Clear"
-            text-enabled
-            appearance="clear"
-          >
+          <calcite-action text="Clear" text-enabled appearance="clear">
             <calcite-icon icon="configure-popup" scale="s"></calcite-icon>
           </calcite-action>
 
-          <calcite-action
-            active
-            text="Clear + active"
-            text-enabled
-            appearance="clear"
-          >
+          <calcite-action active text="Clear + active" text-enabled appearance="clear">
             <calcite-icon icon="configure-popup" scale="s"></calcite-icon>
           </calcite-action>
 
@@ -102,7 +104,6 @@
             <calcite-action indicator text="hello world 2">
               <calcite-icon icon="data-check" scale="s"></calcite-icon>
             </calcite-action>
-
           </div>
         </div>
       </section>


### PR DESCRIPTION
**Related Issue:** None

## Summary

Allow SVGs to be slotted into the calcite-action. At least temporarily until we can figure out a way to determine if the default slot is populated with an element.
