### PR TITLE
fix(shell-panel): style for deprecated leading and trailing attributes

### DIFF
--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -53,9 +53,11 @@
   display: none;
 }
 
+:host([layout="leading"]) slot[name="action-bar"]::slotted(calcite-action-bar), // deprecated
 :host([position="start"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
   border-right: 1px solid var(--calcite-app-border);
 }
+:host([layout="trailing"]) slot[name="action-bar"]::slotted(calcite-action-bar), // deprecated 
 :host([position="end"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
   border-left: 1px solid var(--calcite-app-border);
 }

--- a/src/demos/shell/demo-app-full-window.html
+++ b/src/demos/shell/demo-app-full-window.html
@@ -144,7 +144,7 @@
             </calcite-block>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" position="end" detached detached-scale="l">
+          <calcite-shell-panel slot="contextual-panel" position="end">
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Add" active>


### PR DESCRIPTION
**Related Issue:** #846

## Summary
Added back styles for deprecated attributes.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
