### PR TITLE
feat: props and style for fab

### DIFF
--- a/src/components/calcite-fab/calcite-fab.e2e.ts
+++ b/src/components/calcite-fab/calcite-fab.e2e.ts
@@ -43,12 +43,12 @@ describe("calcite-fab", () => {
     expect(button).toHaveAttribute("disabled");
   });
 
-  it("should have appearance=solid", async () => {
+  it("should have appearance=outline", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-fab text="hello world"></calcite-fab>`);
 
     const fab = await page.find("calcite-fab >>> .button");
-    expect(fab.getAttribute("appearance")).toBe("solid");
+    expect(fab.getAttribute("appearance")).toBe("outline");
   });
 
   it("should be accessible", async () => {

--- a/src/components/calcite-fab/calcite-fab.tsx
+++ b/src/components/calcite-fab/calcite-fab.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Host, Method, Prop, h } from "@stencil/core";
-import { CalciteTheme } from "../interfaces";
+import { CalciteAppearance, CalciteScale, CalciteTheme } from "../interfaces";
 import { CSS, ICONS } from "./resources";
 import { focusElement, getElementDir } from "../utils/dom";
 
@@ -16,9 +16,19 @@ export class CalciteFab {
   // --------------------------------------------------------------------------
 
   /**
+   * Used to set the button's appearance.
+   */
+  @Prop({ reflect: true }) appearance: CalciteAppearance = "clear";
+
+  /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
    */
   @Prop({ reflect: true }) disabled = false;
+
+  /**
+   * The name of the icon to display. The value of this property must match the icon name from https://esri.github.io/calcite-ui-icons/.
+   */
+  @Prop() icon?: string = ICONS.plus;
 
   /**
    * Label of the FAB, exposed on hover. If no label is provided, the label inherits what's provided for the `text` prop.
@@ -29,6 +39,11 @@ export class CalciteFab {
    * When true, content is waiting to be loaded. This state shows a busy indicator.
    */
   @Prop({ reflect: true }) loading = false;
+
+  /**
+   * Specifies the size of the fab.
+   */
+  @Prop({ reflect: true }) scale: CalciteScale = "m";
 
   /**
    * Text that accompanies the FAB icon.
@@ -73,7 +88,18 @@ export class CalciteFab {
   // --------------------------------------------------------------------------
 
   render() {
-    const { disabled, el, loading, theme, textEnabled, label, text } = this;
+    const {
+      appearance,
+      disabled,
+      el,
+      loading,
+      scale,
+      theme,
+      textEnabled,
+      icon,
+      label,
+      text
+    } = this;
     const titleText = !textEnabled && text;
     const title = label || titleText;
     const dir = getElementDir(el);
@@ -88,12 +114,12 @@ export class CalciteFab {
           aria-label={label}
           theme={theme}
           dir={dir}
-          scale="m"
-          icon={ICONS.plus}
+          scale={scale}
+          icon={icon}
           round={true}
           floating={true}
           width="auto"
-          appearance="solid"
+          appearance={appearance}
           color="blue"
           ref={(buttonEl) => (this.buttonEl = buttonEl)}
         >

--- a/src/components/calcite-fab/calcite-fab.tsx
+++ b/src/components/calcite-fab/calcite-fab.tsx
@@ -16,9 +16,9 @@ export class CalciteFab {
   // --------------------------------------------------------------------------
 
   /**
-   * Used to set the button's appearance.
+   * Used to set the button's appearance. Default is outline.
    */
-  @Prop({ reflect: true }) appearance: CalciteAppearance = "clear";
+  @Prop({ reflect: true }) appearance: CalciteAppearance = "outline";
 
   /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.

--- a/src/components/calcite-fab/readme.md
+++ b/src/components/calcite-fab/readme.md
@@ -1,9 +1,6 @@
 # calcite-fab
 
-
-
 <!-- Auto Generated Below -->
-
 
 ## Usage
 
@@ -33,33 +30,28 @@ Renders a `calcite-fab` that is loading and disabled.
 <calcite-fab loading disabled></calcite-fab>
 ```
 
-
-
 ## Properties
 
-| Property      | Attribute      | Description                                                                                                          | Type                | Default     |
-| ------------- | -------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
-| `disabled`    | `disabled`     | When true, disabled prevents interaction. This state shows items with lower opacity/grayed.                          | `boolean`           | `false`     |
-| `label`       | `label`        | Label of the fab, exposed on hover. If no label is provided, the label inherits what's provided for the `text` prop. | `string`            | `undefined` |
-| `loading`     | `loading`      | When true, content is waiting to be loaded. This state shows a busy indicator.                                       | `boolean`           | `false`     |
-| `text`        | `text`         | Text that accompanies the fab icon.                                                                                  | `string`            | `undefined` |
-| `textEnabled` | `text-enabled` | Indicates whether the text is displayed.                                                                             | `boolean`           | `false`     |
-| `theme`       | `theme`        | Used to set the component's color scheme.                                                                            | `"dark" or "light"` | `undefined` |
-
+| Property      | Attribute      | Description                                                                                                                         | Type                | Default     |
+| ------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `appearance`  | `appearance`   | Used to set the button's appearance. Default is outline.                                                                            | `CalciteAppearance` | `outline`   |
+| `disabled`    | `disabled`     | When true, disabled prevents interaction. This state shows items with lower opacity/grayed.                                         | `boolean`           | `false`     |
+| `icon`        | `icon`         | The name of the icon to display. The value of this property must match the icon name from https://esri.github.io/calcite-ui-icons/. | `string`            | `plus`      |
+| `label`       | `label`        | Label of the fab, exposed on hover. If no label is provided, the label inherits what's provided for the `text` prop.                | `string`            | `undefined` |
+| `loading`     | `loading`      | When true, content is waiting to be loaded. This state shows a busy indicator.                                                      | `boolean`           | `false`     |
+| `scale`       | `scale`        | Specifies the size of the fab.                                                                                                      | `CalciteScale`      | `m`         |
+| `text`        | `text`         | Text that accompanies the fab icon.                                                                                                 | `string`            | `undefined` |
+| `textEnabled` | `text-enabled` | Indicates whether the text is displayed.                                                                                            | `boolean`           | `false`     |
+| `theme`       | `theme`        | Used to set the component's color scheme.                                                                                           | `"dark" or "light"` | `undefined` |
 
 ## Methods
 
 ### `setFocus() => Promise<void>`
 
-
-
 #### Returns
 
 Type: `Promise<void>`
 
+---
 
-
-
-----------------------------------------------
-
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -110,4 +110,5 @@
   bottom: 0;
   display: inline-block;
   margin: 0 auto;
+  padding: var(--calcite-app-cap-spacing) 0;
 }

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -10,6 +10,6 @@ export type CalciteBlockSectionToggleDisplay = "button" | "switch";
 
 export type FlowDirection = "advancing" | "retreating";
 
-export type CalciteAppearance = "solid" | "clear";
+export type CalciteAppearance = "solid" | "clear" | "outline";
 
 export type CalciteScale = "s" | "m" | "l";

--- a/src/demos/fab/basic.html
+++ b/src/demos/fab/basic.html
@@ -21,6 +21,17 @@
         <h2>RTL With text</h2>
         <calcite-fab dir="rtl" text-enabled text="Add" label="Add"></calcite-fab>
       </section>
+      <section class="example-container">
+        <h2>Sizes</h2>
+        <calcite-fab text-enabled text="Small" label="Small" icon="banana" scale="s"></calcite-fab>
+        <calcite-fab text-enabled text="Medium (medium)" label="Medium (medium)" icon="banana"></calcite-fab>
+        <calcite-fab text-enabled text="Large" label="Large" icon="banana" scale="l"></calcite-fab>
+      </section>
+      <section class="example-container">
+        <h2>Appearance</h2>
+        <calcite-fab text-enabled text="Clear (default)" label="Clear (default)" icon="banana"></calcite-fab>
+        <calcite-fab text-enabled text="Solid" label="Solid" appearance="solid" icon="banana"></calcite-fab>
+      </section>
     </main>
   </body>
 </html>


### PR DESCRIPTION
**Related Issue:** #815 

## Summary
Minor updates. Mostly adding pass-through props.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->