### PR TITLE
refactor(block, block-section, filter): make intl props optional and add fallbacks

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.e2e.ts
+++ b/src/components/calcite-block-section/calcite-block-section.e2e.ts
@@ -19,14 +19,6 @@ describe("calcite-block-section", () => {
   it("has property defaults", async () =>
     defaults("calcite-block-section", [
       {
-        propertyName: "intlCollapse",
-        defaultValue: TEXT.collapse
-      },
-      {
-        propertyName: "intlExpand",
-        defaultValue: TEXT.expand
-      },
-      {
         propertyName: "open",
         defaultValue: false
       },

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -24,12 +24,12 @@ export class CalciteBlockSection {
   /**
    * Tooltip used for the toggle when expanded.
    */
-  @Prop() intlCollapse = TEXT.collapse;
+  @Prop() intlCollapse?: string;
 
   /**
    * Tooltip used for the toggle when collapsed.
    */
-  @Prop() intlExpand = TEXT.expand;
+  @Prop() intlExpand?: string;
 
   /**
    * When true, the block's section content will be displayed.
@@ -138,7 +138,9 @@ export class CalciteBlockSection {
       ? ICONS.menuClosedLeft
       : ICONS.menuClosedRight;
 
-    const toggleLabel = open ? intlCollapse || textCollapse : intlExpand || textExpand;
+    const toggleLabel = open
+      ? intlCollapse || textCollapse || TEXT.collapse
+      : intlExpand || textExpand || TEXT.expand;
     const labelId = `${id}__label`;
 
     const headerNode =

--- a/src/components/calcite-block/calcite-block.e2e.ts
+++ b/src/components/calcite-block/calcite-block.e2e.ts
@@ -15,14 +15,6 @@ describe("calcite-block", () => {
         defaultValue: false
       },
       {
-        propertyName: "intlCollapse",
-        defaultValue: TEXT.collapse
-      },
-      {
-        propertyName: "intlExpand",
-        defaultValue: TEXT.expand
-      },
-      {
         propertyName: "open",
         defaultValue: false
       }

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -43,12 +43,12 @@ export class CalciteBlock {
   /**
    * Tooltip used for the toggle when expanded.
    */
-  @Prop() intlCollapse = TEXT.collapse;
+  @Prop() intlCollapse?: string;
 
   /**
    * Tooltip used for the toggle when collapsed.
    */
-  @Prop() intlExpand = TEXT.expand;
+  @Prop() intlExpand?: string;
 
   /**
    * When true, content is waiting to be loaded. This state shows a busy indicator.
@@ -137,7 +137,9 @@ export class CalciteBlock {
       textExpand
     } = this;
 
-    const toggleLabel = open ? intlCollapse || textCollapse : intlExpand || textExpand;
+    const toggleLabel = open
+      ? intlCollapse || textCollapse || TEXT.collapse
+      : intlExpand || textExpand || TEXT.expand;
 
     const hasIcon = el.querySelector(`[slot=${SLOTS.icon}]`);
     const headerContent = (

--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -1,6 +1,5 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
-import { TEXT } from "../calcite-filter/resources";
+import { accessible, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-filter", () => {
   it("renders", async () => renders("calcite-filter"));
@@ -8,18 +7,6 @@ describe("calcite-filter", () => {
   it("honors hidden attribute", async () => hidden("calcite-filter"));
 
   it("is accessible", async () => accessible("calcite-filter"));
-
-  it("has property defaults", async () =>
-    defaults("calcite-filter", [
-      {
-        propertyName: "intlClear",
-        defaultValue: TEXT.clear
-      },
-      {
-        propertyName: "intlLabel",
-        defaultValue: TEXT.filterLabel
-      }
-    ]));
 
   describe("strings", () => {
     it("should update the filter placeholder when a string is provided", async () => {

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -25,19 +25,19 @@ export class CalciteFilter {
   /**
    * A text label that will appear on the clear button.
    */
-  @Prop() intlClear: string = TEXT.clear;
+  @Prop() intlClear?: string;
 
   /**
    * A text label that will appear next to the input field.
    */
-  @Prop() intlLabel: string = TEXT.filterLabel;
+  @Prop() intlLabel?: string;
 
   /**
    * A text label that will appear next to the input field.
    *
    * @deprecated since 5.4.0 - use "intlLabel" instead.
    */
-  @Prop() textLabel: string;
+  @Prop() textLabel?: string;
 
   /**
    * Placeholder text for the input element's placeholder attribute
@@ -131,7 +131,7 @@ export class CalciteFilter {
             value=""
             placeholder={this.textPlaceholder}
             onInput={this.inputHandler}
-            aria-label={this.intlLabel || this.textLabel}
+            aria-label={this.intlLabel || this.textLabel || TEXT.filterLabel}
             ref={(el) => (this.textInput = el as HTMLInputElement)}
           />
           <div class={CSS.searchIcon}>
@@ -139,7 +139,11 @@ export class CalciteFilter {
           </div>
         </label>
         {!this.empty ? (
-          <button onClick={this.clear} class={CSS.clearButton} aria-label={this.intlClear}>
+          <button
+            onClick={this.clear}
+            class={CSS.clearButton}
+            aria-label={this.intlClear || TEXT.clear}
+          >
             <calcite-icon icon={ICONS.close} />
           </button>
         ) : null}


### PR DESCRIPTION
**Related Issue:** #818 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This addresses omitted changes from this PR: https://github.com/Esri/calcite-app-components/pull/852#discussion_r384863609