### PR TITLE
feat(filter): add placeholder property

### DIFF
--- a/src/components/calcite-filter/calcite-filter.e2e.ts
+++ b/src/components/calcite-filter/calcite-filter.e2e.ts
@@ -12,7 +12,7 @@ describe("calcite-filter", () => {
     it("should update the filter placeholder when a string is provided", async () => {
       const page = await newE2EPage();
       const placeholderText = "hide em";
-      await page.setContent(`<calcite-filter text-placeholder="${placeholderText}"></calcite-filter>`);
+      await page.setContent(`<calcite-filter placeholder="${placeholderText}"></calcite-filter>`);
 
       const input = await page.find(`calcite-filter >>> input`);
       expect(await input.getProperty("placeholder")).toBe(placeholderText);

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -136,7 +136,7 @@ export class CalciteFilter {
           <input
             type="text"
             value=""
-            placeholder={this.textPlaceholder || this.placeholder}
+            placeholder={this.placeholder || this.textPlaceholder}
             onInput={this.inputHandler}
             aria-label={this.intlLabel || this.textLabel || TEXT.filterLabel}
             ref={(el) => (this.textInput = el as HTMLInputElement)}

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -136,7 +136,7 @@ export class CalciteFilter {
           <input
             type="text"
             value=""
-            placeholder={this.textPlaceholder}
+            placeholder={this.textPlaceholder || this.placeholder}
             onInput={this.inputHandler}
             aria-label={this.intlLabel || this.textLabel || TEXT.filterLabel}
             ref={(el) => (this.textInput = el as HTMLInputElement)}

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -33,6 +33,11 @@ export class CalciteFilter {
   @Prop() intlLabel?: string;
 
   /**
+   * Placeholder text for the input element's placeholder attribute
+   */
+  @Prop() placeholder?: string;
+
+  /**
    * A text label that will appear next to the input field.
    *
    * @deprecated since 5.4.0 - use "intlLabel" instead.
@@ -41,8 +46,10 @@ export class CalciteFilter {
 
   /**
    * Placeholder text for the input element's placeholder attribute
+   *
+   * @deprecated since 5.4.0 - use "placeholder" instead.
    */
-  @Prop() textPlaceholder: string;
+  @Prop() textPlaceholder?: string;
 
   // --------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This adds `placeholder` to `calcite-filter`. This prop deprecates `textPlaceholder` since it does not have a default value and therefore does not need the `text` prefix.