### PR TITLE
Issue #822: Use getSlotted util to reduce boilerplate

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Event, EventEmitter, Host, Prop, Watch, h } from "@
 import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
 import { CSS, SLOTS } from "./resources";
-import { getCalcitePosition } from "../utils/dom";
+import { getCalcitePosition, getSlotted } from "../utils/dom";
 
 /**
  * @slot bottom-actions - A slot for adding `calcite-action`s that will appear at the bottom of the action bar, above the collapse/expand button.
@@ -136,7 +136,7 @@ export class CalciteActionBar {
       />
     ) : null;
 
-    return this.el.querySelector(`[slot=${SLOTS.bottomActions}]`) || expandToggleNode ? (
+    return getSlotted(el, SLOTS.bottomActions)[0] || expandToggleNode ? (
       <calcite-action-group class={CSS.actionGroupBottom}>
         <slot name={SLOTS.bottomActions} />
         {expandToggleNode}

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil
 import { CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { CalciteTheme } from "../interfaces";
 import CalciteScrim from "../utils/CalciteScrim";
+import { getSlotted } from "../utils/dom";
 
 /**
  * @slot icon - A slot for adding a trailing header icon.
@@ -141,7 +142,7 @@ export class CalciteBlock {
       ? intlCollapse || textCollapse || TEXT.collapse
       : intlExpand || textExpand || TEXT.expand;
 
-    const hasIcon = el.querySelector(`[slot=${SLOTS.icon}]`);
+    const [hasIcon] = getSlotted(el, SLOTS.icon);
     const headerContent = (
       <header class={CSS.header}>
         {hasIcon ? (
@@ -156,7 +157,7 @@ export class CalciteBlock {
       </header>
     );
 
-    const slottedControl = el.querySelector(`[slot=${SLOTS.control}]`);
+    const [slottedControl] = getSlotted(el, SLOTS.control);
 
     const headerNode = (
       <div class={CSS.headerContainer}>

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil/core";
 import { VNode } from "@stencil/core/internal";
-import { focusElement, getElementDir } from "../utils/dom";
+import { focusElement, getElementDir, getSlotted } from "../utils/dom";
 import classnames from "classnames";
 import { BLACKLISTED_MENU_ACTIONS_COMPONENTS, CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { SLOTS as PANEL_SLOTS } from "../calcite-panel/resources";
@@ -255,7 +255,7 @@ export class CalciteFlowItem {
   }
 
   renderFooterActions(): VNode {
-    const hasFooterActions = !!this.el.querySelector(`[slot=${SLOTS.footerActions}]`);
+    const hasFooterActions = !!getSlotted(this.el, SLOTS.footerActions)[0];
 
     return hasFooterActions ? (
       <div slot={PANEL_SLOTS.footer} class={CSS.footerActions}>
@@ -282,7 +282,7 @@ export class CalciteFlowItem {
   }
 
   renderHeaderActions(): VNode {
-    const menuActionsNode = this.el.querySelector(`[slot=${SLOTS.menuActions}]`);
+    const [menuActionsNode] = getSlotted(this.el, SLOTS.menuActions);
 
     const hasMenuActionsInBlacklisted =
       menuActionsNode && menuActionsNode.closest(BLACKLISTED_MENU_ACTIONS_COMPONENTS.join(","));

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -10,7 +10,7 @@ import {
   h
 } from "@stencil/core";
 import { CSS, ICONS, SLOTS, TEXT } from "./resources";
-import { getElementDir } from "../utils/dom";
+import { getElementDir, getSlotted } from "../utils/dom";
 import classnames from "classnames";
 import { CSS_UTILITY } from "../utils/resources";
 import { VNode } from "@stencil/core/internal";
@@ -141,7 +141,7 @@ export class CalcitePanel {
   // --------------------------------------------------------------------------
 
   renderHeaderLeadingContent(): VNode {
-    const hasLeadingContent = this.el.querySelector(`[slot=${SLOTS.headerLeadingContent}]`);
+    const [hasLeadingContent] = getSlotted(this.el, SLOTS.headerLeadingContent);
     return hasLeadingContent ? (
       <div key="header-leading-content" class={CSS.headerLeadingContent}>
         <slot name={SLOTS.headerLeadingContent} />
@@ -201,7 +201,7 @@ export class CalcitePanel {
   renderFooter(): VNode {
     const { el } = this;
 
-    const hasFooter = el.querySelector(`[slot=${SLOTS.footer}]`);
+    const [hasFooter] = getSlotted(el, SLOTS.footer);
 
     return hasFooter ? (
       <footer class={CSS.footer}>

--- a/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
+++ b/src/components/calcite-pick-list-group/calcite-pick-list-group.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Host, Prop, h } from "@stencil/core";
 import classnames from "classnames";
 import { CSS, SLOTS } from "./resources";
 import { CSS_UTILITY } from "../utils/resources";
-import { getElementDir } from "../utils/dom";
+import { getElementDir, getSlotted } from "../utils/dom";
 
 /**
  * @slot - A slot for adding `calcite-pick-list-item` elements.
@@ -41,7 +41,7 @@ export class CalcitePickListGroup {
   render() {
     const { el, textGroupTitle } = this;
     const rtl = getElementDir(el) === "rtl";
-    const hasParentItem = el.querySelector(`[slot=${SLOTS.parentItem}]`) !== null;
+    const hasParentItem = getSlotted(el, SLOTS.parentItem)[0] !== null;
     const sectionClasses = {
       [CSS.indented]: hasParentItem,
       [CSS_UTILITY.rtl]: rtl

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -11,6 +11,7 @@ import {
 } from "@stencil/core";
 import { CSS, ICONS, SLOTS } from "./resources";
 import { ICON_TYPES } from "../calcite-pick-list/resources";
+import { getSlotted } from "../utils/dom";
 
 /**
  * @slot secondary-action - A slot intended for adding a `calcite-action` or `calcite-button` to the right side of the card.
@@ -208,7 +209,7 @@ export class CalcitePickListItem {
   }
 
   renderSecondaryAction() {
-    const hasSecondaryAction = this.el.querySelector(`[slot=${SLOTS.secondaryAction}]`);
+    const [hasSecondaryAction] = getSlotted(this.el, SLOTS.secondaryAction);
     return hasSecondaryAction ? (
       <div class={CSS.action}>
         <slot name={SLOTS.secondaryAction} />

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Host, Prop, h } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { CalciteTheme } from "../interfaces";
 import classnames from "classnames";
-import { getCalcitePosition } from "../utils/dom";
+import { getCalcitePosition, getSlotted } from "../utils/dom";
 
 /**
  * @slot shell-header - A slot for adding header content. This content will be positioned at the top of the shell.
@@ -44,7 +44,7 @@ export class CalciteShell {
   // --------------------------------------------------------------------------
 
   renderHeader() {
-    const hasHeader = !!this.el.querySelector(`[slot=${SLOTS.header}]`);
+    const hasHeader = !!getSlotted(this.el, SLOTS.header)[0];
 
     return hasHeader ? <slot name={SLOTS.header} /> : null;
   }
@@ -58,7 +58,7 @@ export class CalciteShell {
   }
 
   renderFooter() {
-    const hasFooter = !!this.el.querySelector(`[slot=${SLOTS.footer}]`);
+    const hasFooter = !!getSlotted(this.el, SLOTS.footer)[0];
 
     return hasFooter ? (
       <div class={CSS.footer}>
@@ -68,9 +68,7 @@ export class CalciteShell {
   }
 
   renderMain() {
-    const primaryPanel = this.el.querySelector(
-      `[slot=${SLOTS.primaryPanel}]`
-    ) as HTMLCalciteShellPanelElement;
+    const [primaryPanel] = getSlotted<HTMLCalciteShellPanelElement>(this.el, SLOTS.primaryPanel);
 
     const mainClasses = {
       [CSS.mainReversed]: getCalcitePosition(primaryPanel?.position, primaryPanel?.layout) === "end"

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Event, EventEmitter, Host, Prop, h } from "@stencil
 import { CalciteTheme } from "../interfaces";
 import { CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { VNode } from "@stencil/core/internal";
+import { getSlotted } from "../utils/dom";
 
 /**
  * @slot thumbnail - A slot for adding an HTML image element to the tip.
@@ -109,7 +110,7 @@ export class CalciteTip {
   renderImageFrame(): VNode {
     const { el } = this;
 
-    return el.querySelector(`[slot=${SLOTS.thumbnail}]`) ? (
+    return getSlotted(el, SLOTS.thumbnail)[0] ? (
       <div class={CSS.imageFrame}>
         <slot name={SLOTS.thumbnail} />
       </div>


### PR DESCRIPTION
**Related Issue:** #822 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
