### PR TITLE
docs(storybook): fix all relative readme links

### DIFF
--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -34,7 +34,7 @@ export const parseReadme = (content: string): string => {
       .replace(/ \\\| /g, " | ")
 
       // markdown uses relative paths for component links
-      .replace(/ \.\.\/ /g, "https://github.com/Esri/calcite-app-components/tree/master/src/components/")
+      .replace(/\.\.\//g, "https://github.com/Esri/calcite-app-components/tree/master/src/components/")
   );
 };
 

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -30,9 +30,6 @@ export const darkBackground = [
 export const parseReadme = (content: string): string => {
   return (
     content
-      // strip out escape characters to not render them
-      .replace(/ \\\| /g, " | ")
-
       // markdown uses relative paths for component links
       .replace(/\.\.\//g, "https://github.com/Esri/calcite-app-components/tree/master/src/components/")
   );

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -34,7 +34,7 @@ export const parseReadme = (content: string): string => {
       .replace(/ \\\| /g, " | ")
 
       // markdown uses relative paths for component links
-      .replace("../", "https://github.com/Esri/calcite-app-components/tree/master/src/components/")
+      .replace(/ \.\.\/ /g, "https://github.com/Esri/calcite-app-components/tree/master/src/components/")
   );
 };
 


### PR DESCRIPTION
**Related Issue:** #828 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This fixes the relative link replacement logic, which was only being applied to the first match.

**Note**: this also removes necessary escape char removal (markdown content renders fine without it).

cc @kat10140 