### PR TITLE
chore: use optional chaining wherever applicable

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -297,8 +297,9 @@ export class CalciteFlowItem {
   renderHeaderActions(): VNode {
     const menuActionsNode = this.el.querySelector(`[slot=${SLOTS.menuActions}]`);
 
-    const hasMenuActionsInBlacklisted =
-      menuActionsNode && menuActionsNode.closest(BLACKLISTED_MENU_ACTIONS_COMPONENTS.join(","));
+    const hasMenuActionsInBlacklisted = menuActionsNode?.closest(
+      BLACKLISTED_MENU_ACTIONS_COMPONENTS.join(",")
+    );
 
     const hasMenuActions = !!menuActionsNode && !hasMenuActionsInBlacklisted;
     const actionCount = hasMenuActions ? menuActionsNode.childElementCount : 0;

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -187,7 +187,7 @@ export class CalciteTipManager {
   updateGroupTitle() {
     const selectedTip = this.tips[this.selectedIndex];
     const tipParent = selectedTip.closest("calcite-tip-group");
-    this.groupTitle = (tipParent && tipParent.textGroupTitle) || this.textDefaultTitle;
+    this.groupTitle = tipParent.textGroupTitle || this.textDefaultTitle;
   }
 
   previousClicked = (): void => {

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -187,7 +187,7 @@ export class CalciteTipManager {
   updateGroupTitle() {
     const selectedTip = this.tips[this.selectedIndex];
     const tipParent = selectedTip.closest("calcite-tip-group");
-    this.groupTitle = tipParent.textGroupTitle || this.textDefaultTitle;
+    this.groupTitle = tipParent?.textGroupTitle || this.textDefaultTitle;
   }
 
   previousClicked = (): void => {

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -8,7 +8,7 @@ export async function setUpPage(content: string, options?: SetUpPageOptions): Pr
   const page = await newE2EPage();
   await page.setContent(content);
 
-  if (options && options.withPeerDependencies) {
+  if (options?.withPeerDependencies) {
     await page.addScriptTag({
       url: "vendor/@esri/calcite-components/calcite.esm.js",
       type: "module"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

![3r39dp](https://user-images.githubusercontent.com/197440/75636410-575a8a80-5bd3-11ea-8231-76eda1d5359b.jpg)
