### PR TITLE
fix(flow-item): update to only show fab-container when fab slot is used

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -347,11 +347,12 @@ export class CalciteFlowItem {
   }
 
   renderFab(): VNode {
-    return (
+    const hasFab = this.el.querySelector(`[slot=${SLOTS.fab}]`);
+    return hasFab ? (
       <div class={CSS.fabContainer} slot={PANEL_SLOTS.fab}>
         <slot name={SLOTS.fab} />
       </div>
-    );
+    ) : null;
   }
 
   render() {


### PR DESCRIPTION
**Related Issue:** See 1322 in webviewer repo.

## Summary
- Added a check for the `fab` slot in flow-item
- `fab-container` will only show if the slot is used.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
