### PR TITLE
fix(action): Add slotChildNodesFix to stencil config extras

### DIFF
--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -130,7 +130,7 @@ export class CalciteAction {
     const calciteLoaderNode = loading ? <calcite-loader is-active inline /> : null;
     const calciteIconNode = icon ? <calcite-icon icon={icon} scale={iconScale} /> : null;
     const iconNode = calciteLoaderNode || calciteIconNode;
-    const hasIconToDisplay = iconNode || el.querySelector("calcite-icon, svg");
+    const hasIconToDisplay = iconNode || el.children?.length;
 
     const slotContainerNode = (
       <div

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -368,7 +368,7 @@ export class CalciteFlowItem {
   }
 
   renderFab(): VNode {
-    const hasFab = this.el.querySelector(`[slot=${SLOTS.fab}]`);
+    const hasFab = getSlotted(this.el, SLOTS.fab);
     return hasFab ? (
       <div class={CSS.fabContainer} slot={PANEL_SLOTS.fab}>
         <slot name={SLOTS.fab} />

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -240,7 +240,7 @@ export class CalcitePanel {
   }
 
   renderFab(): VNode {
-    const hasFab = this.el.querySelector(`[slot=${SLOTS.fab}]`);
+    const hasFab = getSlotted(this.el, SLOTS.fab);
 
     return hasFab ? (
       <div class={CSS.fabContainer}>

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -61,7 +61,8 @@ export const create: () => Config = () => ({
   excludeSrc: DEFAULT_EXCLUDE_SRC,
   srcIndexHtml: "src/index.html",
   extras: {
-    appendChildSlotFix: true
+    appendChildSlotFix: true,
+    slotChildNodesFix: true
   }
 });
 


### PR DESCRIPTION
**Related Issue:** None

## Summary

```ts
/**
     * For browsers that do not support shadow dom (IE11 and Edge 18 and below), slot is polyfilled
     * to simulate the same behavior. However, the host element's `childNodes` and `children`
     * getters are not patched to only show the child nodes and elements of the default slot.
     * Defaults to `false`.
     */
    slotChildNodesFix?: boolean;
```

@jcfranco do you remember which component we were trying to find out if the default slot is populated?