### PR TITLE
chore: update project config

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -3,8 +3,6 @@ import { postcss } from "@stencil/postcss";
 import { sass } from "@stencil/sass";
 import autoprefixer from "autoprefixer";
 
-const DEFAULT_EXCLUDE_SRC = ["**/*.stories.ts", "**/tests/**"];
-
 export const create: () => Config = () => ({
   namespace: "calcite-app",
   bundles: [
@@ -58,7 +56,6 @@ export const create: () => Config = () => ({
     setupFilesAfterEnv: ["<rootDir>/src/tests/setup.ts"]
   },
   srcDir: "src/components",
-  excludeSrc: DEFAULT_EXCLUDE_SRC,
   srcIndexHtml: "src/index.html",
   extras: {
     appendChildSlotFix: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig-base",
-  "include": [".storybook/*", "src", "node_modules/@esri/calcite-components/dist/types/components.d.ts"]
+  "include": [
+    ".storybook/declarations.d.ts",
+    "src",
+    "node_modules/@esri/calcite-components/dist/types/components.d.ts"
+  ],
+  "exclude": ["**/*.stories.ts", "**/tests/**"]
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

The latest Stencil release deprecated `excludeSrc` from `stencil.config.ts` and instead uses  `tsconfig.json` for exclusions. This updates our config accordingly.
