### PR TITLE
fix(block): use CSS grid to improve header layout

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -17,8 +17,8 @@
 }
 
 .header-container {
-  position: relative;
-  display: flex;
+  display: grid;
+  grid: auto auto / auto minmax(0, 1fr);
   align-items: center;
 
   & > .header {
@@ -53,6 +53,8 @@ calcite-loader[inline] {
 }
 
 .toggle {
+  grid-column: 1 / 3;
+  grid-row: 1 / 2;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -85,9 +87,10 @@ calcite-loader[inline] {
 }
 
 ::slotted([slot="control"]) {
-  position: absolute;
-  margin: auto;
-  right: var(--calcite-app-side-spacing-three-quarters);
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+  justify-self: end;
+  margin: auto var(--calcite-app-side-spacing-three-quarters) auto auto;
 }
 
 .calcite--rtl {

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -18,7 +18,8 @@
 
 .header-container {
   display: grid;
-  grid: auto auto / auto minmax(0, 1fr);
+  grid-template: auto / auto auto 1fr;
+  grid-template-areas: "handle header control";
   align-items: center;
 
   & > .header {
@@ -39,6 +40,10 @@ calcite-loader[inline] {
   color: var(--calcite-app-foreground-subtle);
 }
 
+calcite-handle {
+  grid-area: handle;
+}
+
 .title {
   margin: 0;
 }
@@ -53,8 +58,7 @@ calcite-loader[inline] {
 }
 
 .toggle {
-  grid-column: 1 / 3;
-  grid-row: 1 / 2;
+  grid-area: header;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -87,8 +91,7 @@ calcite-loader[inline] {
 }
 
 ::slotted([slot="control"]) {
-  grid-column: 2 / 3;
-  grid-row: 1 / 2;
+  grid-area: control;
   justify-self: end;
   margin: auto var(--calcite-app-side-spacing-three-quarters) auto auto;
 }

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -58,7 +58,8 @@ calcite-handle {
 }
 
 .toggle {
-  grid-area: header;
+  grid-column: header-start / control-end;
+  grid-row: 1 / 2;
   display: flex;
   align-items: center;
   justify-content: flex-end;


### PR DESCRIPTION
**Related Issue:** #849

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [x] changes have been tested with demo page in Edge
-->

This updates Block to use CSS grid for its layout to avoid an issue where a control may flow outside its container.