### PR TITLE
feat(block): drop open/close icon

### DIFF
--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h, VNode } from "@stencil/core";
-import { CSS, ICONS, SLOTS, TEXT } from "./resources";
+import { CSS, SLOTS, TEXT } from "./resources";
 import { CalciteTheme } from "../interfaces";
 import CalciteScrim from "../utils/CalciteScrim";
 import { getSlotted } from "../utils/dom";
@@ -157,8 +157,6 @@ export class CalciteBlock {
       </header>
     );
 
-    const slottedControl = getSlotted(el, SLOTS.control);
-
     const headerNode = (
       <div class={CSS.headerContainer}>
         {this.dragHandle ? <calcite-handle /> : null}
@@ -170,9 +168,6 @@ export class CalciteBlock {
             title={toggleLabel}
           >
             {headerContent}
-            {slottedControl ? null : (
-              <calcite-icon scale="s" icon={open ? ICONS.close : ICONS.open} />
-            )}
           </button>
         ) : (
           headerContent

--- a/src/components/calcite-block/resources.ts
+++ b/src/components/calcite-block/resources.ts
@@ -17,11 +17,6 @@ export const TEXT = {
   expand: "Expand"
 };
 
-export const ICONS = {
-  close: "chevron-up",
-  open: "chevron-down"
-};
-
 export const enum SLOTS {
   icon = "icon",
   control = "control"

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -71,8 +71,7 @@
 
         <h2>With drag handle</h2>
 
-        <calcite-block heading="Heading" summary="summary" drag-handle="true">          <label slot="control">test <input placeholder="I'm a header control"/></label>
-        </calcite-block>
+        <calcite-block heading="Heading" summary="summary" drag-handle="true"></calcite-block>
 
         <section dir="rtl">
           <h2>RTL</h2>

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -57,13 +57,6 @@
           </calcite-block-section>
         </calcite-block>
 
-        <h2>Header + collapsible + control = no collapsible icon</h2>
-
-        <calcite-block heading="no toggle icon when there is a control" collapsible>
-          <label slot="control">test</label>
-          <div>Some content</div>
-        </calcite-block>
-
         <h2>Header + content (sections w/ switch)</h2>
 
         <calcite-block heading="Heading" summary="summary" open collapsible>
@@ -78,7 +71,8 @@
 
         <h2>With drag handle</h2>
 
-        <calcite-block heading="Heading" summary="summary" drag-handle="true"></calcite-block>
+        <calcite-block heading="Heading" summary="summary" drag-handle="true">          <label slot="control">test <input placeholder="I'm a header control"/></label>
+        </calcite-block>
 
         <section dir="rtl">
           <h2>RTL</h2>


### PR DESCRIPTION
**Related Issue:** #896 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Removes block header caret per updated block design. 👋🥕