### PR TITLE
feat(action-bar,action-pad): Allow access to toggle action

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -7,12 +7,15 @@ import {
   Prop,
   Watch,
   h,
+  Method,
   VNode
 } from "@stencil/core";
 import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
 import { CSS, SLOTS, TEXT } from "./resources";
 import { getCalcitePosition, getSlotted } from "../utils/dom";
+
+type GetElementId = "expand-action";
 
 /**
  * @slot bottom-actions - A slot for adding `calcite-action`s that will appear at the bottom of the action bar, above the collapse/expand button.
@@ -98,6 +101,17 @@ export class CalciteActionBar {
 
   // --------------------------------------------------------------------------
   //
+  //  Public Methods
+  //
+  // --------------------------------------------------------------------------
+
+  @Method()
+  async getElement(id: GetElementId): Promise<HTMLCalciteActionElement | null> {
+    return id === "expand-action" ? this.toggleEl : null;
+  }
+
+  // --------------------------------------------------------------------------
+  //
   //  Events
   //
   // --------------------------------------------------------------------------
@@ -114,6 +128,8 @@ export class CalciteActionBar {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteActionBarElement;
+
+  toggleEl: HTMLCalciteActionElement;
 
   // --------------------------------------------------------------------------
   //
@@ -170,6 +186,7 @@ export class CalciteActionBar {
         el={el}
         position={getCalcitePosition(position, layout)}
         toggleExpand={toggleExpand}
+        ref={(toggleEl): HTMLCalciteActionElement => (this.toggleEl = toggleEl)}
       />
     ) : null;
 

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -7,12 +7,15 @@ import {
   Prop,
   Watch,
   h,
+  Method,
   VNode
 } from "@stencil/core";
 import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
 import { CSS, TEXT } from "./resources";
 import { getCalcitePosition } from "../utils/dom";
+
+type GetElementId = "expand-action";
 
 /**
  * @slot - A slot for adding `calcite-action`s to the action pad.
@@ -93,6 +96,19 @@ export class CalciteActionPad {
    */
   @Prop({ reflect: true }) theme: CalciteTheme;
 
+  @Prop() toggleEl: HTMLCalciteActionElement;
+
+  // --------------------------------------------------------------------------
+  //
+  //  Public Methods
+  //
+  // --------------------------------------------------------------------------
+
+  @Method()
+  async getElement(id: GetElementId): Promise<HTMLCalciteActionElement | null> {
+    return id === "expand-action" ? this.toggleEl : null;
+  }
+
   // --------------------------------------------------------------------------
   //
   //  Events
@@ -167,6 +183,7 @@ export class CalciteActionPad {
         el={el}
         position={getCalcitePosition(position, layout)}
         toggleExpand={toggleExpand}
+        ref={(toggleEl): HTMLCalciteActionElement => (this.toggleEl = toggleEl)}
       />
     ) : null;
 

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -96,8 +96,6 @@ export class CalciteActionPad {
    */
   @Prop({ reflect: true }) theme: CalciteTheme;
 
-  @Prop() toggleEl: HTMLCalciteActionElement;
-
   // --------------------------------------------------------------------------
   //
   //  Public Methods
@@ -127,6 +125,8 @@ export class CalciteActionPad {
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteActionBarElement;
+
+  toggleEl: HTMLCalciteActionElement;
 
   // --------------------------------------------------------------------------
   //

--- a/src/components/utils/CalciteExpandToggle.tsx
+++ b/src/components/utils/CalciteExpandToggle.tsx
@@ -8,6 +8,7 @@ interface CalciteExpandToggleProps {
   intlCollapse: string;
   el: HTMLElement;
   position: CalcitePosition;
+  ref: (el: HTMLCalciteActionElement) => void;
   toggleExpand: () => void;
 }
 
@@ -49,7 +50,8 @@ export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> 
   intlCollapse,
   toggleExpand,
   el,
-  position
+  position,
+  ref
 }) => {
   const rtl = getElementDir(el) === "rtl";
 
@@ -65,7 +67,7 @@ export const CalciteExpandToggle: FunctionalComponent<CalciteExpandToggleProps> 
   const collapseIcon = end ? icons[0] : icons[1];
 
   return (
-    <calcite-action onClick={toggleExpand} textEnabled={expanded} text={expandText}>
+    <calcite-action ref={ref} onClick={toggleExpand} textEnabled={expanded} text={expandText}>
       <calcite-icon scale="s" icon={expanded ? expandIcon : collapseIcon} />
     </calcite-action>
   );

--- a/src/demos/action-bar/basic.html
+++ b/src/demos/action-bar/basic.html
@@ -107,6 +107,27 @@
                   </calcite-action-bar>
                 </div>
               </section>
+              <section>
+                <h3>Tooltip on expand toggle</h3>
+                <div class="action-bar-container">
+                  <calcite-action-bar id="tooltip-action-bar">
+                    <calcite-action text="Add">
+                      <calcite-icon icon="plus" scale="s"></calcite-icon>
+                    </calcite-action>
+                  </calcite-action-bar>
+                  <calcite-tooltip id="tooltip">Hello world!</calcite-tooltip>
+                  <script>
+                    var actionBar = document.getElementById("tooltip-action-bar");
+                    window.addEventListener("load", function () {
+                      actionBar.getElement("expand-action").then((el) => {
+                        var tooltip = document.getElementById("tooltip");
+                        tooltip.referenceElement = el;
+                        tooltip.open = true;
+                      });
+                    });
+                  </script>
+                </div>
+              </section>
             </div>
           </section>
           <section>


### PR DESCRIPTION
**Related Issue:** None

## Summary

Allow access to toggle collapse/expand action in order to be able to use it as a reference for the tooltip.

@jcfranco another option is maybe we have a property `toggleTooltip` that a user can set the tooltip and then internally we set the referenceElement on it? Then we don't expose the node via a method but we can set it on the tooltip.
