### PR TITLE
fix(flow-item): fix back button icon not showing up

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -251,7 +251,7 @@ export class CalciteFlowItem {
         class={CSS.backButton}
         onClick={backButtonClick}
       >
-        <calcite-icon scale="s" filled icon={icon} />
+        <calcite-icon scale="s" icon={icon} />
       </calcite-action>
     ) : null;
   }

--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -43,7 +43,7 @@ const createAttributes: () => Attributes = () => [
 
 const action = dedent`
   <calcite-action slot="secondary-action" label="click-me" onClick="console.log('clicked');" appearance="clear">
-    <calcite-icon icon="circle" scale="s" filled style="color: #f689d8;"></calcite-icon>
+    <calcite-icon icon="circle" scale="s" style="color: #f689d8;"></calcite-icon>
   </calcite-action>
 `;
 

--- a/src/components/calcite-value-list/calcite-value-list.stories.ts
+++ b/src/components/calcite-value-list/calcite-value-list.stories.ts
@@ -47,7 +47,7 @@ const createAttributes: () => Attributes = () => [
 
 const action = dedent`
   <calcite-action slot="secondary-action" label="click-me" onClick="console.log('clicked');" appearance="clear">
-    <calcite-icon icon="circle" scale="s" filled style="color: #f689d8;"></calcite-icon>
+    <calcite-icon icon="circle" scale="s" style="color: #f689d8;"></calcite-icon>
   </calcite-action>
 `;
 


### PR DESCRIPTION
Also updates other calcite-icons to not use filled attribute.

**Related Issue:** #902 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Drops `filled` attribute, which was dropped in the latest `calcite-components` release.
