### PR TITLE
build: fix release script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16436,9 +16436,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.1.1.tgz",
-      "integrity": "sha512-wAeu/ePaBAOfwM2+cVbgPWDtn17B0Sxiv0NvNEqDAIvB8Yhvl60vafKFiK4grcYn87K1iK+a0zVoETvKbdT9/Q==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.1.0.tgz",
+      "integrity": "sha512-WzZ/T+O/aEaaT679sMgI4JqK5mnG69V5KQSouzVsShzZ8wGWte39HT3z61LsxjVNeCf8m/ChhvWJa2wTiQLy5A==",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "jest-axe": "3.4.0",
     "jest-cli": "24.9.0",
     "jest-runner": "24.9.0",
-    "lint-staged": "10.1.1",
+    "lint-staged": "10.1.0",
     "package": "1.0.1",
     "posthtml": "0.12.0",
     "prettier": "2.0.2",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Rollback `lint-staged` since it trips up the release script.