### PR TITLE
fix(action, flow, pick-list, sortable-list, tip-manager, value-list): react to DOM mutations earlier to avoid stagnant renders

### DIFF
--- a/src/components/calcite-action/calcite-action.tsx
+++ b/src/components/calcite-action/calcite-action.tsx
@@ -101,7 +101,7 @@ export class CalciteAction {
   //
   // --------------------------------------------------------------------------
 
-  componentDidLoad(): void {
+  connectedCallback(): void {
     this.observer.observe(this.el, { childList: true, subtree: true });
   }
 

--- a/src/components/calcite-flow/calcite-flow.tsx
+++ b/src/components/calcite-flow/calcite-flow.tsx
@@ -78,9 +78,6 @@ export class CalciteFlow {
 
   connectedCallback(): void {
     this.flowItemObserver.observe(this.el, { childList: true, subtree: true });
-  }
-
-  componentWillLoad(): void {
     this.updateFlowProps();
   }
 

--- a/src/components/calcite-flow/calcite-flow.tsx
+++ b/src/components/calcite-flow/calcite-flow.tsx
@@ -76,12 +76,12 @@ export class CalciteFlow {
   //
   // --------------------------------------------------------------------------
 
-  componentWillLoad(): void {
-    this.updateFlowProps();
+  connectedCallback(): void {
+    this.flowItemObserver.observe(this.el, { childList: true, subtree: true });
   }
 
-  componentDidLoad(): void {
-    this.flowItemObserver.observe(this.el, { childList: true, subtree: true });
+  componentWillLoad(): void {
+    this.updateFlowProps();
   }
 
   componentDidUnload(): void {

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -110,9 +110,6 @@ export class CalcitePickList<
 
   connectedCallback(): void {
     initialize.call(this);
-  }
-
-  componentDidLoad(): void {
     initializeObserver.call(this);
   }
 

--- a/src/components/calcite-sortable-list/calcite-sortable-list.tsx
+++ b/src/components/calcite-sortable-list/calcite-sortable-list.tsx
@@ -68,7 +68,7 @@ export class CalciteSortableList {
   //
   // --------------------------------------------------------------------------
 
-  componentDidLoad(): void {
+  connectedCallback(): void {
     this.items = Array.from(this.el.children);
     this.setUpDragAndDrop();
     this.beginObserving();

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -137,9 +137,6 @@ export class CalciteTipManager {
 
   connectedCallback(): void {
     this.setUpTips();
-  }
-
-  componentDidLoad(): void {
     this.observer.observe(this.el, { childList: true, subtree: true });
   }
 

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -119,9 +119,6 @@ export class CalciteValueList<
   // --------------------------------------------------------------------------
   connectedCallback(): void {
     initialize.call(this);
-  }
-
-  componentDidLoad(): void {
     this.setUpDragAndDrop();
     initializeObserver.call(this);
   }


### PR DESCRIPTION
**Related Issue:** #919 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This addresses an issue that arose when components were used in another VDOM library ([maquette](https://github.com/AFASSoftware/maquette)) and children were added after `connectedCallback` (`MutationObserver` is initialized), but before `componentWillLoad` (`MutationObserver` starts observing), preventing some initialization logic from kicking in. 

cc @AdelheidF 