### PR TITLE
fix(value-list): restore DND setup

### DIFF
--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -117,10 +117,14 @@ export class CalciteValueList<
   //  Lifecycle
   //
   // --------------------------------------------------------------------------
+
   connectedCallback(): void {
     initialize.call(this);
-    this.setUpDragAndDrop();
     initializeObserver.call(this);
+  }
+
+  componentDidLoad(): void {
+    this.setUpDragAndDrop();
   }
 
   componentDidUnload(): void {


### PR DESCRIPTION
**Related Issue:** #919 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Moves value-list DND setup back to `componentDidLoad`. This shouldn't have moved in the first place since it doesn't kick in on DOM mutations.

cc @AdelheidF 