### PR TITLE
fix(pick-list-item): update filled circle icon setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3073,9 +3073,9 @@
       "integrity": "sha512-LT6nA6HrVB9j53Du1O+WuKK1stoGVVxHCeO9RKKUgYDHDcvnzSNBwNyn95hzQzEgSoeoD8MOu7jxSn6TplAQuw=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.0-beta.21",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.21.tgz",
-      "integrity": "sha512-1S4lxHXOrFp5gPqNX3N31A7xSWYq4VWSU3nE9Y9o+cEZpyMeGTaLxRzhecMIHutyRhnk2iBaJBg3Hg/bDq6/eg==",
+      "version": "1.0.0-beta.23",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.23.tgz",
+      "integrity": "sha512-R+yBtG1Ujl2JfSelW7lmrzZyp2t+8ioj/41vGqIDQ+wBGGBj010nFt6ykv/1fWHJgQynzy0yfBJtEfi0rwTSUQ==",
       "dev": true,
       "requires": {
         "@a11y/focus-trap": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3073,9 +3073,9 @@
       "integrity": "sha512-LT6nA6HrVB9j53Du1O+WuKK1stoGVVxHCeO9RKKUgYDHDcvnzSNBwNyn95hzQzEgSoeoD8MOu7jxSn6TplAQuw=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.23.tgz",
-      "integrity": "sha512-R+yBtG1Ujl2JfSelW7lmrzZyp2t+8ioj/41vGqIDQ+wBGGBj010nFt6ykv/1fWHJgQynzy0yfBJtEfi0rwTSUQ==",
+      "version": "1.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.24.tgz",
+      "integrity": "sha512-L9keek1tDFqSfQiKS5zLYlSRy43HwAmCKTsYhQzGx4er3GE3rGL4r8Y8a3Vb55vTBYsFQ1+cC4EMF9e50jSLig==",
       "dev": true,
       "requires": {
         "@a11y/focus-trap": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "sortablejs": "1.10.2"
   },
   "devDependencies": {
-    "@esri/calcite-components": "1.0.0-beta.21",
+    "@esri/calcite-components": "1.0.0-beta.23",
     "@stencil/core": "1.12.1",
     "@stencil/eslint-plugin": "0.3.1",
     "@stencil/postcss": "1.0.1",
@@ -109,7 +109,7 @@
     "updtr": "3.1.0"
   },
   "peerDependencies": {
-    "@esri/calcite-components": "1.0.0-beta.21"
+    "@esri/calcite-components": "1.0.0-beta.23"
   },
   "license": "UNLICENSED"
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "sortablejs": "1.10.2"
   },
   "devDependencies": {
-    "@esri/calcite-components": "1.0.0-beta.23",
+    "@esri/calcite-components": "1.0.0-beta.24",
     "@stencil/core": "1.12.1",
     "@stencil/eslint-plugin": "0.3.1",
     "@stencil/postcss": "1.0.1",
@@ -109,7 +109,7 @@
     "updtr": "3.1.0"
   },
   "peerDependencies": {
-    "@esri/calcite-components": "1.0.0-beta.23"
+    "@esri/calcite-components": "1.0.0-beta.24"
   },
   "license": "UNLICENSED"
 }

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -235,7 +235,7 @@ export class CalcitePickListItem {
 
     return (
       <span class={CSS.icon}>
-        <calcite-icon filled={iconName === ICONS.circle && selected} scale="s" icon={iconName} />
+        <calcite-icon scale="s" icon={iconName} />
       </span>
     );
   }

--- a/src/components/calcite-pick-list-item/resources.ts
+++ b/src/components/calcite-pick-list-item/resources.ts
@@ -14,7 +14,7 @@ export const CSS = {
 export const ICONS = {
   unchecked: "square",
   checked: "check",
-  circle: "circle",
+  circle: "circleF",
   remove: "x"
 };
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

`calcite-components@v1.0.0-beta.23` dropped `calcite-icon`'s `filled` attribute and has a different naming convention for a few filled icons.