### PR TITLE
chore: revisit prepublish error messaging

### DIFF
--- a/support/prepublish.ts
+++ b/support/prepublish.ts
@@ -5,28 +5,14 @@ const branch = childProcess.execSync("git rev-parse --abbrev-ref HEAD");
 if (branch.toString().trim() === "master") {
   process.exit();
 } else {
-  console.log(
-    chalk.green(
-      `
-  *  ______     ______     __         ______     __     ______   ______
-  * /\\  ___\\   /\\  __ \\   /\\ \\       /\\  ___\\   /\\ \\   /\\__  _\\ /\\  ___\\
-  * \\ \\ \\____  \\ \\  __ \\  \\ \\ \\____  \\ \\ \\____  \\ \\ \\  \\/_/\\ \\/ \\ \\  __\\
-  *  \\ \\_____\\  \\ \\_\\ \\_\\  \\ \\_____\\  \\ \\_____\\  \\ \\_\\    \\ \\_\\  \\ \\_____\\
-  *   \\/_____/   \\/_/\\/_/   \\/_____/   \\/_____/   \\/_/     \\/_/   \\/_____/
-  *  ______     ______     ______     ______     ______
-  * /\\  ___\\   /\\  == \\   /\\  == \\   /\\  __ \\   /\\  == \\
-  * \\ \\  __\\   \\ \\  __<   \\ \\  __<   \\ \\ \\/\\ \\  \\ \\  __<
-  *  \\ \\_____\\  \\ \\_\\ \\_\\  \\ \\_\\ \\_\\  \\ \\_____\\  \\ \\_\\ \\_\\
-  *   \\/_____/   \\/_/ /_/   \\/_/ /_/   \\/_____/   \\/_/ /_/
-  *
-  *`,
-      chalk.red(
-        `You may only run`,
-        chalk.white("$ npm publish"),
-        `from the master branch. You are on ${branch.toString()}.
-  `
-      )
-    )
+  const message = chalk.red(
+    `Error: ${chalk.white(
+      `You may only run ${chalk.green("npm publish")} from the ${chalk.yellow(
+        "master"
+      )} branch. You are on ${chalk.yellow(branch)}.`
+    )}`
   );
+
+  console.error(message);
   process.exit(1);
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Tone down `prepublish.ts` error messaging:

**before**

<img width="750" alt="Screen Shot 2020-04-23 at 4 20 31 PM" src="https://user-images.githubusercontent.com/197440/80159829-d25f7200-8580-11ea-9762-8ead9e6e201d.png">

**after**

<img width="771" alt="Screen Shot 2020-04-23 at 4 32 18 PM" src="https://user-images.githubusercontent.com/197440/80159814-c1aefc00-8580-11ea-878c-0d1f505d3afc.png">

