### PR TITLE
feat: replace focus ring mixin and added new mixin where needed

### DIFF
--- a/src/components/calcite-action/calcite-action.scss
+++ b/src/components/calcite-action/calcite-action.scss
@@ -24,7 +24,7 @@
   transition: color 125ms ease-in-out, fill 125ms ease-in-out, background-color 125ms ease-in-out;
   text-align: unset;
   position: relative;
-
+  @include focus-style-base();
   &:hover,
   &:focus {
     background-color: var(--calcite-app-background-hover);
@@ -32,7 +32,9 @@
     fill: var(--calcite-app-foreground-hover);
   }
 
-  @include focusRingInset();
+  &:focus {
+    @include focus-style-inset();
+  }
 
   .icon-container {
     min-width: var(--calcite-app-icon-size);

--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -45,7 +45,10 @@
   font-size: var(--calcite-app-font-size-0);
   text-align: unset;
   color: var(--calcite-app-foreground);
-  @include focusRingInset();
+  @include focus-style-base();
+  &:focus {
+    @include focus-style-inset();
+  }
 }
 
 .header,

--- a/src/components/calcite-handle/calcite-handle.scss
+++ b/src/components/calcite-handle/calcite-handle.scss
@@ -16,14 +16,14 @@
   color: var(--calcite-app-border);
   line-height: 0;
   cursor: move;
-  @include focusRingInset();
-  &:focus {
-    outline-offset: var(--calcite-app-outline-inset);
-    color: var(--calcite-app-foreground);
-  }
   &:hover {
     background-color: var(--calcite-app-background-hover);
     color: var(--calcite-app-foreground);
+  }
+  @include focus-style-base();
+  &:focus {
+    color: var(--calcite-app-foreground);
+    @include focus-style-inset();
   }
   &--activated {
     background-color: var(--calcite-app-background-active);

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.scss
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.scss
@@ -37,8 +37,10 @@
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-quarter);
   align-items: center;
   cursor: pointer;
-
-  @include focusRingInset();
+  @include focus-style-base();
+  &:focus {
+    @include focus-style-inset();
+  }
 }
 
 .text-container {

--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -46,6 +46,10 @@ $tip-max-width: 540px;
   position: relative;
   padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half) 0;
   min-height: 150px;
+  @include focus-style-base();
+  &:focus {
+    @include focus-style-outset();
+  }
 }
 
 .tip-container {
@@ -57,6 +61,10 @@ $tip-max-width: 540px;
   display: flex;
   justify-content: center;
   align-items: flex-start;
+  @include focus-style-base();
+  &:focus {
+    @include focus-style-inset();
+  }
 }
 
 ::slotted(calcite-tip-group) {

--- a/src/components/calcite-tip/calcite-tip.scss
+++ b/src/components/calcite-tip/calcite-tip.scss
@@ -62,6 +62,11 @@ $tip-image-max-width: 100% !default;
 
 ::slotted(a) {
   color: var(--calcite-app-foreground-link);
+  @include focus-style-base();
+}
+
+::slotted(a:focus) {
+  @include focus-style-outset();
 }
 
 .image-frame {

--- a/src/components/calcite-value-list-item/calcite-value-list-item.scss
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.scss
@@ -38,12 +38,15 @@ calcite-pick-list-item {
   color: var(--calcite-app-border);
   line-height: 0;
   cursor: move;
-  @include focusRingInset();
+  @include focus-style-base();
   &:hover,
   &:focus {
     background-color: var(--calcite-app-background-hover);
     outline-offset: var(--calcite-app-outline-inset);
     color: var(--calcite-app-foreground);
+  }
+  &:focus {
+    @include focus-style-inset();
   }
   &--activated {
     background-color: var(--calcite-app-background-active);

--- a/src/demos/tip/basic.html
+++ b/src/demos/tip/basic.html
@@ -25,7 +25,7 @@
             <p>
               This is another paragraph in a subsequent "info" slot.
             </p>
-            <a href="http://www.esri.com">This is the "link" slot.</a>
+            <a href="http://www.esri.com">This is a link.</a>
           </calcite-tip>
         </div>
         <hr />
@@ -52,7 +52,7 @@
             <p>
               This is another paragraph in a subsequent "info" slot.
             </p>
-            <a href="http://www.esri.com">This is the "link" slot.</a>
+            <a href="http://www.esri.com">This is a link.</a>
           </calcite-tip>
         </div>
         <h2>Without header</h2>
@@ -65,7 +65,7 @@
             <p>
               This is another paragraph in a subsequent "info" slot.
             </p>
-            <a href="http://www.esri.com">This is the "link" slot.</a>
+            <a href="http://www.esri.com">This is a link.</a>
           </calcite-tip>
         </div>
         <hr />

--- a/src/scss/mixins/_utilities.scss
+++ b/src/scss/mixins/_utilities.scss
@@ -23,8 +23,20 @@
   -webkit-box-orient: vertical;
 }
 
-@mixin focusRingInset() {
-  &:focus {
-    outline-offset: var(--calcite-app-outline-inset);
-  }
+// place on the element that receives focus style, not in focus
+@mixin focus-style-base() {
+  outline-offset: 0;
+  outline-color: transparent;
+  transition: outline-offset 100ms ease-in-out, outline-color 100ms ease-in-out;
+}
+
+// place on the element that receives focus style, while in focus
+@mixin focus-style-outset() {
+  outline: 2px solid var(--calcite-ui-blue-1);
+  outline-offset: 2px;
+}
+
+@mixin focus-style-inset() {
+  outline: 2px solid var(--calcite-ui-blue-1);
+  outline-offset: -2px;
 }

--- a/src/scss/mixins/_utilities.scss
+++ b/src/scss/mixins/_utilities.scss
@@ -27,7 +27,8 @@
 @mixin focus-style-base() {
   outline-offset: 0;
   outline-color: transparent;
-  transition: outline-offset 100ms ease-in-out, outline-color 100ms ease-in-out;
+  transition: outline-offset var(--calcite-app-animation-time-fast) ease-in-out,
+    outline-color var(--calcite-app-animation-time-fast) ease-in-out;
 }
 
 // place on the element that receives focus style, while in focus


### PR DESCRIPTION
**Related Issue:** #945 

## Summary
* Add new :focus mixin to match calcite-components.
* Replace old mixin with new
* Added new mixin where needed

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

cc @macandcheese let me know if there's a way to pull those mixins in from calcite-components. I'm currently reproducing them.
