### PR TITLE
fix(block): loader UI bug

### DIFF
--- a/src/components/calcite-block/calcite-block.scss
+++ b/src/components/calcite-block/calcite-block.scss
@@ -55,6 +55,8 @@
 
 calcite-loader[inline] {
   color: var(--calcite-app-foreground-subtle);
+  grid-area: control;
+  align-self: center;
 }
 
 calcite-handle {


### PR DESCRIPTION
**Related Issue:** #941 

## Summary
Fix for loading state in Block header.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
