### PR TITLE
feat(panel): tweak for FAB slot when h-scroll

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -110,5 +110,7 @@
   bottom: 0;
   display: inline-block;
   margin: 0 auto;
-  padding: var(--calcite-app-cap-spacing) 0;
+  padding: var(--calcite-app-cap-spacing-half) var(--calcite-app-side-spacing-half);
+  left: 0;
+  right: 0;
 }

--- a/src/demos/shell/demo-app-advanced-center-row.html
+++ b/src/demos/shell/demo-app-advanced-center-row.html
@@ -132,6 +132,7 @@
             <calcite-panel heading="Data table" summary="US Demographics - Country - County">
               <calcite-action slot="header-leading-content" text="Switch layer" icon="caret-down"></calcite-action>
               <calcite-action slot="header-trailing-content" text="Expand" icon="expand" id="expand-trigger"></calcite-action>
+              <calcite-fab slot="fab"></calcite-fab>
               <div class="header" slot="header-content">
                 Data table<br/>US Demographics - Country - County
               </div>


### PR DESCRIPTION
**Related Issue:** #952

## Summary
Little tweak to handle when FAB is in a Panel inside ShellCenterRow and stuff goes sideways. Sideways like scrolling horizontally.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

cc @kat10140 
