### PR TITLE
docs(shell-center-row): tip-manager usage

### DIFF
--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -155,8 +155,8 @@ const contentHTML = dedent`
   "></div>
 `;
 
-const tipManagerHTML = dedent`
-  <calcite-tip-manager slot="tip-manager">
+const centerRowAdvancedHTML = dedent`
+  <calcite-tip-manager>
     <calcite-tip-group text-group-title="Astronomy">
       <calcite-tip heading="The Red Rocks and Blue Water">
         <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
@@ -326,9 +326,8 @@ export const advanced = (): string =>
     ${headerHTML}
     ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), advancedLeadingPanelHTML)}
     ${contentHTML}
-    ${create("calcite-shell-center-row", createShellCenterRowAttributes("Center Row"), centerRowHTML)}
+    ${create("calcite-shell-center-row", createShellCenterRowAttributes("Center Row"), centerRowAdvancedHTML)}
     ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), advancedTrailingPanelHTMl)}
-    ${tipManagerHTML}
     ${footerHTML}
   `
   );

--- a/src/components/calcite-shell/calcite-shell.stories.ts
+++ b/src/components/calcite-shell/calcite-shell.stories.ts
@@ -156,7 +156,7 @@ const contentHTML = dedent`
 `;
 
 const centerRowAdvancedHTML = dedent`
-  <calcite-tip-manager>
+  <calcite-tip-manager slot="center-row">
     <calcite-tip-group text-group-title="Astronomy">
       <calcite-tip heading="The Red Rocks and Blue Water">
         <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
@@ -326,7 +326,7 @@ export const advanced = (): string =>
     ${headerHTML}
     ${create("calcite-shell-panel", createShellPanelAttributes("Leading Panel"), advancedLeadingPanelHTML)}
     ${contentHTML}
-    ${create("calcite-shell-center-row", createShellCenterRowAttributes("Center Row"), centerRowAdvancedHTML)}
+    ${centerRowAdvancedHTML}
     ${create("calcite-shell-panel", createShellPanelAttributes("Trailing Panel"), advancedTrailingPanelHTMl)}
     ${footerHTML}
   `

--- a/src/components/calcite-shell/usage/advanced.md
+++ b/src/components/calcite-shell/usage/advanced.md
@@ -62,10 +62,12 @@ Renders a shell with leading and trailing floating panels, action bar/pad, block
         </calcite-flow-item>
       </calcite-flow>
   </calcite-shell-panel>
-  <calcite-tip-manager slot="tip-manager">
-    <calcite-tip heading="The Red Rocks and Blue Water" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of nature.">
-    <calcite-tip heading="The Long Trees" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of trees.">
-  </calcite-tip-manager>
+  <calcite-shell-center-row slot="center-row" position="end" height-scale="m">
+    <calcite-tip-manager>
+      <calcite-tip heading="The Red Rocks and Blue Water" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of nature.">
+      <calcite-tip heading="The Long Trees" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of trees.">
+    </calcite-tip-manager>
+  </calcite-shell-center-row>
   <footer slot="shell-footer">Footer</footer>
 </calcite-shell>
 ```

--- a/src/components/calcite-shell/usage/advanced.md
+++ b/src/components/calcite-shell/usage/advanced.md
@@ -62,12 +62,10 @@ Renders a shell with leading and trailing floating panels, action bar/pad, block
         </calcite-flow-item>
       </calcite-flow>
   </calcite-shell-panel>
-  <calcite-shell-center-row slot="center-row" position="end" height-scale="m">
-    <calcite-tip-manager>
-      <calcite-tip heading="The Red Rocks and Blue Water" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of nature.">
-      <calcite-tip heading="The Long Trees" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of trees.">
-    </calcite-tip-manager>
-  </calcite-shell-center-row>
+  <calcite-tip-manager slot="center-row">
+    <calcite-tip heading="The Red Rocks and Blue Water" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of nature.">
+    <calcite-tip heading="The Long Trees" thumbnail="https://placeimg.com/1000/600" text-thumbnail="This is an image of trees.">
+  </calcite-tip-manager>
   <footer slot="shell-footer">Footer</footer>
 </calcite-shell>
 ```

--- a/src/components/calcite-shell/usage/basic.md
+++ b/src/components/calcite-shell/usage/basic.md
@@ -27,6 +27,9 @@ Renders a shell with a header and panels on the left and right sides of the app.
   <calcite-shell-panel slot="contextual-panel" position="end">
     Trailing panel! (right side)
   </calcite-shell-panel>
+  <calcite-shell-center-row slot="center-row" position="end" height-scale="m">
+    Center Row! (center bottom)
+  </calcite-shell-center-row>
   <div slot="shell-header">
     <header>
       <h2>Shell Header: My App</h2>


### PR DESCRIPTION
**Related Issue:** None

## Summary

CalciteTipManager should work in `center-row` slot