### PR TITLE
fix(block-section): added rtl check and css

### DIFF
--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, Prop, h, VNode } from "@stencil/core";
 
 import { getElementDir } from "../utils/dom";
+import { CSS_UTILITY } from "../utils/resources";
 import { CSS, ICONS, TEXT } from "./resources";
 import { guid } from "../utils/guid";
 import { CalciteBlockSectionToggleDisplay } from "../interfaces";
@@ -167,7 +168,7 @@ export class CalciteBlockSection {
       );
 
     return (
-      <section aria-expanded={open.toString()}>
+      <section aria-expanded={open.toString()} class={dir ? CSS_UTILITY.rtl : null}>
         {headerNode}
         <div class={CSS.content} hidden={!open}>
           <slot />

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -91,7 +91,7 @@
             </calcite-block-section>
           </calcite-block>
 
-          <h3>With sections</h3>
+          <h3>Header + content (sections w/ switch)</h3>
           
           <calcite-block heading="Heading" summary="summary" open collapsible>
             <calcite-block-section text="Animals" open toggle-display="switch">

--- a/src/demos/block/basic.html
+++ b/src/demos/block/basic.html
@@ -90,6 +90,18 @@
               <img alt="demo" src="https://placeimg.com/640/480/nature" />
             </calcite-block-section>
           </calcite-block>
+
+          <h3>With sections</h3>
+          
+          <calcite-block heading="Heading" summary="summary" open collapsible>
+            <calcite-block-section text="Animals" open toggle-display="switch">
+              <img alt="demo" src="https://placeimg.com/640/480/animals" />
+            </calcite-block-section>
+  
+            <calcite-block-section text="Nature" open toggle-display="switch">
+              <img alt="demo" src="https://placeimg.com/640/480/nature" />
+            </calcite-block-section>
+          </calcite-block>
         </section>
       </section>
     </main>


### PR DESCRIPTION
**Related Issue:** #957

## Summary
Add `calcite--rtl` to BlockSection.
This CSS class on Block wasn't affecting BlockSection.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
