### PR TITLE
fix(tip-manager): changed focus style to avoid hidden ring

### DIFF
--- a/src/components/calcite-tip-manager/calcite-tip-manager.scss
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.scss
@@ -57,13 +57,14 @@ $tip-max-width: 540px;
   animation-duration: var(--calcite-app-animation-time);
   animation-timing-function: var(--calcite-app-easing-function);
   height: $tip-manager-height;
+  margin-top: var(--calcite-app-cap-spacing-quarter);
   overflow: auto;
   display: flex;
   justify-content: center;
   align-items: flex-start;
   @include focus-style-base();
   &:focus {
-    @include focus-style-inset();
+    @include focus-style-outset();
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #945 

## Summary
Updated the focus ring to be outset.
<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
cc @kat10140 