### PR TITLE
chore(changelog): use touch alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier:styles": "prettier --write \"src/**/*.scss\"",
     "preversion": "npm ci && npm test",
     "previewChangelog": "standard-version --no-skip.bump --silent && cat CHANGELOG.md && git reset --hard --quiet",
-    "previewChangelog:latest": "git touch __CHANGELOG-PREVIEW-TEMP__ && standard-version --no-skip.bump --release-count 1 --infile __CHANGELOG-PREVIEW-TEMP__ --same-file --silent && cat __CHANGELOG-PREVIEW-TEMP__ && git reset --hard --quiet",
+    "previewChangelog:latest": "npx touch __CHANGELOG-PREVIEW-TEMP__ && standard-version --no-skip.bump --release-count 1 --infile __CHANGELOG-PREVIEW-TEMP__ --same-file --silent && cat __CHANGELOG-PREVIEW-TEMP__ && git reset --hard --quiet",
     "release": "git push --follow-tags && npm publish && ts-node ./support/githubReleaseFromChangelog.ts",
     "start": "concurrently --kill-others --raw \"npm run demoPageSync\" \"tsc --project ./tsconfig-demos.json --watch\" \"stencil build --dev --watch --serve\"",
     "test": "stencil test --spec --e2e",


### PR DESCRIPTION
**Related Issue:** #936 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This uses `https://www.npmjs.com/package/touch` (npx) instead of relying on a 3rd-party git plugin.