### PR TITLE
refactor!: Remove deprecated properties and slots from components

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -9,10 +9,10 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
+import { CalcitePosition, CalciteTheme } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
 import { CSS, SLOTS, TEXT } from "./resources";
-import { getCalcitePosition, getSlotted } from "../utils/dom";
+import { getSlotted } from "../utils/dom";
 
 /**
  * @slot bottom-actions - A slot for adding `calcite-action`s that will appear at the bottom of the action bar, above the collapse/expand button.
@@ -62,33 +62,13 @@ export class CalciteActionBar {
 
   /**
    * Updates the label of the expand icon when the component is not expanded.
-   * @deprecated use "intlExpand" instead.
-   */
-  @Prop() textExpand?: string;
-
-  /**
-   * Updates the label of the expand icon when the component is not expanded.
    */
   @Prop() intlExpand?: string;
 
   /**
    * Updates the label of the collapse icon when the component is expanded.
-   * @deprecated use "intlCollapse" instead.
-   */
-  @Prop() textCollapse?: string;
-
-  /**
-   * Updates the label of the collapse icon when the component is expanded.
    */
   @Prop() intlCollapse?: string;
-
-  /**
-   * Arrangement of the component. Leading and trailing are different depending on if the direction is LTR or RTL. For example, "leading"
-   * in a LTR app will appear on the left.
-   *
-   * @deprecated use "position" instead.
-   */
-  @Prop({ reflect: true }) layout: CalciteLayout;
 
   /**
    * Arranges the component depending on the elements 'dir' property.
@@ -155,17 +135,14 @@ export class CalciteActionBar {
       expand,
       intlExpand,
       intlCollapse,
-      textExpand,
-      textCollapse,
       el,
-      layout,
       position,
       toggleExpand,
       tooltipExpand
     } = this;
 
-    const expandLabel = intlExpand || textExpand || TEXT.expand;
-    const collapseLabel = intlCollapse || textCollapse || TEXT.collapse;
+    const expandLabel = intlExpand || TEXT.expand;
+    const collapseLabel = intlCollapse || TEXT.collapse;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -173,7 +150,7 @@ export class CalciteActionBar {
         intlExpand={expandLabel}
         intlCollapse={collapseLabel}
         el={el}
-        position={getCalcitePosition(position, layout)}
+        position={position}
         toggleExpand={toggleExpand}
         tooltipExpand={tooltipExpand}
       />

--- a/src/components/calcite-action-pad/calcite-action-pad.tsx
+++ b/src/components/calcite-action-pad/calcite-action-pad.tsx
@@ -9,10 +9,9 @@ import {
   h,
   VNode
 } from "@stencil/core";
-import { CalciteLayout, CalcitePosition, CalciteTheme } from "../interfaces";
+import { CalcitePosition, CalciteTheme } from "../interfaces";
 import { CalciteExpandToggle, toggleChildActionText } from "../utils/CalciteExpandToggle";
 import { CSS, TEXT } from "./resources";
-import { getCalcitePosition } from "../utils/dom";
 
 /**
  * @slot - A slot for adding `calcite-action`s to the action pad.
@@ -61,32 +60,13 @@ export class CalciteActionPad {
 
   /**
    * Updates the label of the expand icon when the component is not expanded.
-   * @deprecated use "intlExpand" instead.
-   */
-  @Prop() textExpand?: string;
-
-  /**
-   * Updates the label of the expand icon when the component is not expanded.
    */
   @Prop() intlExpand?: string;
 
   /**
    * Updates the label of the collapse icon when the component is expanded.
-   * @deprecated use "intlCollapse" instead.
-   */
-  @Prop() textCollapse?: string;
-
-  /**
-   * Updates the label of the collapse icon when the component is expanded.
    */
   @Prop() intlCollapse?: string;
-
-  /**
-   * Arrangement of the component.
-   *
-   * @deprecated use "position" instead.
-   */
-  @Prop({ reflect: true }) layout: CalciteLayout;
 
   /**
    * Arranges the component depending on the elements 'dir' property.
@@ -153,17 +133,14 @@ export class CalciteActionPad {
       expand,
       intlExpand,
       intlCollapse,
-      textExpand,
-      textCollapse,
       el,
-      layout,
       position,
       toggleExpand,
       tooltipExpand
     } = this;
 
-    const expandLabel = intlExpand || textExpand || TEXT.expand;
-    const collapseLabel = intlCollapse || textCollapse || TEXT.collapse;
+    const expandLabel = intlExpand || TEXT.expand;
+    const collapseLabel = intlCollapse || TEXT.collapse;
 
     const expandToggleNode = expand ? (
       <CalciteExpandToggle
@@ -171,7 +148,7 @@ export class CalciteActionPad {
         intlExpand={expandLabel}
         intlCollapse={collapseLabel}
         el={el}
-        position={getCalcitePosition(position, layout)}
+        position={position}
         toggleExpand={toggleExpand}
         tooltipExpand={tooltipExpand}
       />

--- a/src/components/calcite-block-section/calcite-block-section.tsx
+++ b/src/components/calcite-block-section/calcite-block-section.tsx
@@ -42,20 +42,6 @@ export class CalciteBlockSection {
   @Prop() text: string;
 
   /**
-   * Tooltip used for the toggle when expanded.
-   *
-   * @deprecated use "intlCollapse" instead.
-   */
-  @Prop() textCollapse?: string;
-
-  /**
-   * Tooltip used for the toggle when collapsed.
-   *
-   * @deprecated use "intlExpand" instead.
-   */
-  @Prop() textExpand?: string;
-
-  /**
    * This property determines the look of the section toggle.
    * If the value is "switch", a toggle-switch will be displayed.
    * If the value is "button", a clickable header is displayed.
@@ -111,17 +97,7 @@ export class CalciteBlockSection {
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const {
-      el,
-      guid: id,
-      intlCollapse,
-      intlExpand,
-      open,
-      text,
-      textCollapse,
-      textExpand,
-      toggleDisplay
-    } = this;
+    const { el, guid: id, intlCollapse, intlExpand, open, text, toggleDisplay } = this;
     const dir = getElementDir(el);
     const arrowIcon = open
       ? ICONS.menuOpen
@@ -129,9 +105,7 @@ export class CalciteBlockSection {
       ? ICONS.menuClosedLeft
       : ICONS.menuClosedRight;
 
-    const toggleLabel = open
-      ? intlCollapse || textCollapse || TEXT.collapse
-      : intlExpand || textExpand || TEXT.expand;
+    const toggleLabel = open ? intlCollapse || TEXT.collapse : intlExpand || TEXT.expand;
     const labelId = `${id}__label`;
 
     const headerNode =

--- a/src/components/calcite-block/calcite-block.tsx
+++ b/src/components/calcite-block/calcite-block.tsx
@@ -68,20 +68,6 @@ export class CalciteBlock {
   @Prop() summary: string;
 
   /**
-   * Tooltip used for the toggle when expanded.
-   *
-   * @deprecated use "intlCollapse" instead.
-   */
-  @Prop() textCollapse?: string;
-
-  /**
-   * Tooltip used for the toggle when collapsed.
-   *
-   * @deprecated use "intlExpand" instead.
-   */
-  @Prop() textExpand?: string;
-
-  /**
    * Used to set the component's color scheme.
    */
   @Prop({ reflect: true }) theme: CalciteTheme;
@@ -132,14 +118,10 @@ export class CalciteBlock {
       intlExpand,
       loading,
       open,
-      summary,
-      textCollapse,
-      textExpand
+      summary
     } = this;
 
-    const toggleLabel = open
-      ? intlCollapse || textCollapse || TEXT.collapse
-      : intlExpand || textExpand || TEXT.expand;
+    const toggleLabel = open ? intlCollapse || TEXT.collapse : intlExpand || TEXT.expand;
 
     const hasIcon = getSlotted(el, SLOTS.icon);
     const headerContent = (

--- a/src/components/calcite-filter/calcite-filter.tsx
+++ b/src/components/calcite-filter/calcite-filter.tsx
@@ -49,20 +49,6 @@ export class CalciteFilter {
    */
   @Prop() placeholder?: string;
 
-  /**
-   * A text label that will appear next to the input field.
-   *
-   * @deprecated use "intlLabel" instead.
-   */
-  @Prop() textLabel?: string;
-
-  /**
-   * Placeholder text for the input element's placeholder attribute
-   *
-   * @deprecated use "placeholder" instead.
-   */
-  @Prop() textPlaceholder?: string;
-
   // --------------------------------------------------------------------------
   //
   //  Private Properties
@@ -150,9 +136,9 @@ export class CalciteFilter {
           <input
             type="text"
             value=""
-            placeholder={this.placeholder || this.textPlaceholder}
+            placeholder={this.placeholder}
             onInput={this.inputHandler}
-            aria-label={this.intlLabel || this.textLabel || TEXT.filterLabel}
+            aria-label={this.intlLabel || TEXT.filterLabel}
             ref={(el): void => {
               this.textInput = el;
             }}

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -72,32 +72,14 @@ export class CalciteFlowItem {
   @Prop() intlBack?: string;
 
   /**
-   * 'Back' text string.
-   * @deprecated use "intlBack" instead.
-   */
-  @Prop() textBack?: string;
-
-  /**
    * 'Close' text string for the close button. The close button will only be shown when 'dismissible' is true.
    */
   @Prop() intlClose?: string;
 
   /**
-   * 'Close' text string for the menu.
-   * @deprecated use "intlClose" instead.
-   */
-  @Prop() textClose?: string;
-
-  /**
    * 'Open' text string for the menu.
    */
   @Prop() intlOpen?: string;
-
-  /**
-   * 'Open' text string for the menu.
-   * @deprecated use "intlOpen" instead.
-   */
-  @Prop() textOpen?: string;
 
   /**
    * Used to set the component's color scheme.
@@ -237,8 +219,8 @@ export class CalciteFlowItem {
   // --------------------------------------------------------------------------
 
   renderBackButton(rtl: boolean): VNode {
-    const { showBackButton, intlBack, textBack, backButtonClick } = this;
-    const label = intlBack || textBack || TEXT.back;
+    const { showBackButton, intlBack, backButtonClick } = this;
+    const label = intlBack || TEXT.back;
     const icon = rtl ? ICONS.backRight : ICONS.backLeft;
 
     return showBackButton ? (
@@ -255,9 +237,9 @@ export class CalciteFlowItem {
   }
 
   renderMenuButton(): VNode {
-    const { menuOpen, textOpen, intlOpen, intlClose, textClose } = this;
-    const closeLabel = intlClose || textClose || TEXT.close;
-    const openLabel = intlOpen || textOpen || TEXT.open;
+    const { menuOpen, intlOpen, intlClose } = this;
+    const closeLabel = intlClose || TEXT.close;
+    const openLabel = intlOpen || TEXT.open;
 
     const menuLabel = menuOpen ? closeLabel : openLabel;
 

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -74,12 +74,6 @@ export class CalcitePanel {
   @Prop() intlClose?: string;
 
   /**
-   * 'Close' text string for the close button. The close button will only be shown when 'dismissible' is true.
-   * @deprecated use "intlClose" instead.
-   */
-  @Prop() textClose?: string;
-
-  /**
    * Used to set the component's color scheme.
    */
   @Prop({ reflect: true }) theme: CalciteTheme;
@@ -174,8 +168,8 @@ export class CalcitePanel {
   }
 
   renderHeaderTrailingContent(): VNode {
-    const { dismiss, dismissible, intlClose, textClose } = this;
-    const text = intlClose || textClose || TEXT.close;
+    const { dismiss, dismissible, intlClose } = this;
+    const text = intlClose || TEXT.close;
 
     const dismissibleNode = dismissible ? (
       <calcite-action

--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -31,14 +31,6 @@ export class CalcitePickListItem {
   // --------------------------------------------------------------------------
 
   /**
-   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute.
-   * This allows for a more compact version of the `calcite-pick-list-item`.
-   *
-   * @deprecated This property will be removed in a future release.
-   */
-  @Prop({ reflect: true }) compact? = false;
-
-  /**
    * When true, the item cannot be clicked and is visually muted.
    */
   @Prop({ reflect: true }) disabled? = false;
@@ -229,9 +221,9 @@ export class CalcitePickListItem {
   // --------------------------------------------------------------------------
 
   renderIcon(): VNode {
-    const { compact, icon } = this;
+    const { icon } = this;
 
-    if (!icon || compact) {
+    if (!icon) {
       return null;
     }
 
@@ -270,10 +262,9 @@ export class CalcitePickListItem {
   }
 
   render(): VNode {
-    const description =
-      this.textDescription && !this.compact ? (
-        <span class={CSS.description}>{this.textDescription}</span>
-      ) : null;
+    const description = this.textDescription ? (
+      <span class={CSS.description}>{this.textDescription}</span>
+    ) : null;
 
     return (
       <Host role="menuitemcheckbox" aria-checked={this.selected.toString()}>

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -47,14 +47,6 @@ export class CalcitePickList<
   // --------------------------------------------------------------------------
 
   /**
-   * Compact removes the selection icon (radio or checkbox) and adds a compact attribute.
-   * This allows for a more compact version of the `calcite-pick-list-item`.
-   *
-   * @deprecated This property will be removed in a future release.
-   */
-  @Prop({ reflect: true }) compact = false;
-
-  /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
    */
   @Prop({ reflect: true }) disabled = false;

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -161,7 +161,6 @@ export function setUpItems<T extends Lists>(
 
   items.forEach((item) => {
     item.icon = this.getIconType();
-    item.compact = this.compact;
     if (!this.multiple) {
       item.disableDeselect = true;
       toggleSingleSelectItemTabbing(item, false);

--- a/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.e2e.ts
@@ -74,20 +74,6 @@ describe("calcite-shell-panel", () => {
     expect(eventSpy).toHaveReceivedEvent();
   });
 
-  it("deprecated: leading layout property should have action slot first", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(
-      '<calcite-shell-panel layout="leading"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
-    );
-
-    const element = await page.find("calcite-shell-panel");
-
-    await page.waitForChanges();
-
-    expect(element.shadowRoot.firstElementChild.tagName).toBe("SLOT");
-  });
-
   it("start position property should have action slot first", async () => {
     const page = await newE2EPage();
 
@@ -100,20 +86,6 @@ describe("calcite-shell-panel", () => {
     await page.waitForChanges();
 
     expect(element.shadowRoot.firstElementChild.tagName).toBe("SLOT");
-  });
-
-  it("deprecated: trailing layout property should have DIV first", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(
-      '<calcite-shell-panel layout="trailing"><div slot="action-bar">bar</div><div>content</div></calcite-shell-panel>'
-    );
-
-    const element = await page.find("calcite-shell-panel");
-
-    await page.waitForChanges();
-
-    expect(element.shadowRoot.firstElementChild.tagName).toBe("DIV");
   });
 
   it("trailing position property should have DIV first", async () => {

--- a/src/components/calcite-shell-panel/calcite-shell-panel.scss
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.scss
@@ -50,11 +50,10 @@
   display: none;
 }
 
-:host([layout="leading"]) slot[name="action-bar"]::slotted(calcite-action-bar), // deprecated
 :host([position="start"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
   border-right: 1px solid var(--calcite-app-border);
 }
-:host([layout="trailing"]) slot[name="action-bar"]::slotted(calcite-action-bar), // deprecated 
+
 :host([position="end"]) slot[name="action-bar"]::slotted(calcite-action-bar) {
   border-left: 1px solid var(--calcite-app-border);
 }

--- a/src/components/calcite-shell-panel/calcite-shell-panel.tsx
+++ b/src/components/calcite-shell-panel/calcite-shell-panel.tsx
@@ -1,7 +1,6 @@
 import { Component, Event, EventEmitter, Host, Prop, Watch, h, VNode } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
-import { CalciteLayout, CalcitePosition, CalciteScale } from "../interfaces";
-import { getCalcitePosition } from "../utils/dom";
+import { CalcitePosition, CalciteScale } from "../interfaces";
 
 /**
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the panel.
@@ -40,13 +39,6 @@ export class CalciteShellPanel {
   @Prop({ reflect: false }) detachedScale: CalciteScale = "m";
 
   /**
-   * Arrangement of the component.
-   *
-   * @deprecated use "position" instead.
-   */
-  @Prop({ reflect: true }) layout: CalciteLayout;
-
-  /**
    * Arranges the component depending on the elements 'dir' property.
    */
   @Prop({ reflect: true }) position: CalcitePosition;
@@ -69,7 +61,7 @@ export class CalciteShellPanel {
   // --------------------------------------------------------------------------
 
   render(): VNode {
-    const { collapsed, detached, layout, position } = this;
+    const { collapsed, detached, position } = this;
 
     const contentNode = (
       <div class={{ [CSS.content]: true, [CSS.contentDetached]: detached }} hidden={collapsed}>
@@ -81,7 +73,7 @@ export class CalciteShellPanel {
 
     const mainNodes = [actionBarNode, contentNode];
 
-    if (getCalcitePosition(position, layout) === "end") {
+    if (position === "end") {
       mainNodes.reverse();
     }
 

--- a/src/components/calcite-shell/calcite-shell.e2e.ts
+++ b/src/components/calcite-shell/calcite-shell.e2e.ts
@@ -51,25 +51,6 @@ describe("calcite-shell", () => {
     </calcite-shell>
     `));
 
-  it("deprecated: flex row should not be reversed", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`<calcite-shell>
-      <calcite-shell-panel slot="${SLOTS.primaryPanel}" layout="leading">
-        <p>Primary Content</p>
-      </calcite-shell-panel>
-      <calcite-shell-panel slot="${SLOTS.contextualPanel}" layout="trailing">
-        <p>Primary Content</p>
-      </calcite-shell-panel>
-    </calcite-shell>`);
-
-    await page.waitForChanges();
-
-    const mainReversed = await page.find(`calcite-shell >>> .${CSS.mainReversed}`);
-
-    expect(mainReversed).toBeNull();
-  });
-
   it("flex row should not be reversed", async () => {
     const page = await newE2EPage();
 
@@ -87,25 +68,6 @@ describe("calcite-shell", () => {
     const mainReversed = await page.find(`calcite-shell >>> .${CSS.mainReversed}`);
 
     expect(mainReversed).toBeNull();
-  });
-
-  it("deprecated: flex row should be reversed", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`<calcite-shell>
-    <calcite-shell-panel slot="${SLOTS.primaryPanel}" layout="trailing">
-      <p>Primary Content</p>
-    </calcite-shell-panel>
-    <calcite-shell-panel slot="${SLOTS.contextualPanel}" layout="leading">
-      <p>Primary Content</p>
-    </calcite-shell-panel>
-  </calcite-shell>`);
-
-    await page.waitForChanges();
-
-    const mainReversed = await page.find(`calcite-shell >>> .${CSS.mainReversed}`);
-
-    expect(mainReversed).not.toBeNull();
   });
 
   it("flex row should be reversed", async () => {

--- a/src/components/calcite-shell/calcite-shell.tsx
+++ b/src/components/calcite-shell/calcite-shell.tsx
@@ -1,14 +1,13 @@
 import { Component, Element, Host, Prop, h, VNode } from "@stencil/core";
 import { CSS, SLOTS } from "./resources";
 import { CalciteTheme } from "../interfaces";
-import { getCalcitePosition, getSlotted } from "../utils/dom";
+import { getSlotted } from "../utils/dom";
 
 /**
  * @slot shell-header - A slot for adding header content. This content will be positioned at the top of the shell.
  * @slot shell-footer - A slot for adding footer content. This content will be positioned at the bottom of the shell.
  * @slot primary-panel - A slot for adding the leading `calcite-shell-panel`.
  * @slot contextual-panel - A slot for adding the trailing `calcite-shell-panel`.
- * @slot tip-manager - **[DEPRECATED]** use "bottom-panel" instead.
  * @slot bottom-panel - A slot for adding a bottom floating panel such as a chart or `calcite-tip-manager`.
  * @slot - A slot for adding content to the shell. This content will appear between any leading and trailing panels added to the shell. (eg. a map)
  */
@@ -72,7 +71,7 @@ export class CalciteShell {
 
     const mainClasses = {
       [CSS.main]: true,
-      [CSS.mainReversed]: getCalcitePosition(primaryPanel?.position, primaryPanel?.layout) === "end"
+      [CSS.mainReversed]: primaryPanel?.position === "end"
     };
 
     return (
@@ -81,7 +80,6 @@ export class CalciteShell {
         {this.renderContent()}
         <slot name={SLOTS.centerRow} />
         <slot name={SLOTS.contextualPanel} />
-        <slot name={SLOTS.tipManager} />
       </div>
     );
   }

--- a/src/components/calcite-shell/resources.ts
+++ b/src/components/calcite-shell/resources.ts
@@ -10,6 +10,5 @@ export const SLOTS = {
   primaryPanel: "primary-panel",
   contextualPanel: "contextual-panel",
   header: "shell-header",
-  footer: "shell-footer",
-  tipManager: "tip-manager"
+  footer: "shell-footer"
 };

--- a/src/components/calcite-tip-manager/calcite-tip-manager.tsx
+++ b/src/components/calcite-tip-manager/calcite-tip-manager.tsx
@@ -46,21 +46,9 @@ export class CalciteTipManager {
   @Prop() intlClose?: string;
 
   /**
-   * Alternate text for closing the tip.
-   * @deprecated use "intlClose" instead.
-   */
-  @Prop() textClose?: string;
-
-  /**
    * The default group title for the `calcite-tip-manager`.
    */
   @Prop() intlDefaultTitle?: string;
-
-  /**
-   * The default group title for the `calcite-tip-manager`.
-   * @deprecated use "intlDefaultTitle" instead.
-   */
-  @Prop() textDefaultTitle?: string;
 
   /**
    * Alternate text for navigating to the next tip.
@@ -68,32 +56,14 @@ export class CalciteTipManager {
   @Prop() intlNext?: string;
 
   /**
-   * Alternate text for navigating to the next tip.
-   * @deprecated use "intlNext" instead.
-   */
-  @Prop() textNext?: string;
-
-  /**
    * Label that appears on hover of pagination icon.
    */
   @Prop() intlPaginationLabel?: string;
 
   /**
-   * Label that appears on hover of pagination icon.
-   * @deprecated use "intlPaginationLabel" instead.
-   */
-  @Prop() textPaginationLabel?: string;
-
-  /**
    * Alternate text for navigating to the previous tip.
    */
   @Prop() intlPrevious?: string;
-
-  /**
-   * Alternate text for navigating to the previous tip.
-   * @deprecated use "intlPrevious" instead.
-   */
-  @Prop() textPrevious?: string;
 
   /**
    * Used to set the component's color scheme.
@@ -214,11 +184,7 @@ export class CalciteTipManager {
   updateGroupTitle(): void {
     const selectedTip = this.tips[this.selectedIndex];
     const tipParent = selectedTip.closest("calcite-tip-group");
-    this.groupTitle =
-      tipParent?.textGroupTitle ||
-      this.intlDefaultTitle ||
-      this.textDefaultTitle ||
-      TEXT.defaultGroupTitle;
+    this.groupTitle = tipParent?.textGroupTitle || this.intlDefaultTitle || TEXT.defaultGroupTitle;
   }
 
   previousClicked = (): void => {
@@ -266,22 +232,11 @@ export class CalciteTipManager {
 
   renderPagination(): VNode {
     const dir = getElementDir(this.el);
-    const {
-      selectedIndex,
-      tips,
-      total,
-      intlNext,
-      textNext,
-      intlPrevious,
-      textPrevious,
-      intlPaginationLabel,
-      textPaginationLabel
-    } = this;
+    const { selectedIndex, tips, total, intlNext, intlPrevious, intlPaginationLabel } = this;
 
-    const nextLabel = intlNext || textNext || TEXT.next;
-    const previousLabel = intlPrevious || textPrevious || TEXT.previous;
-    const paginationLabel =
-      intlPaginationLabel || textPaginationLabel || TEXT.defaultPaginationLabel;
+    const nextLabel = intlNext || TEXT.next;
+    const previousLabel = intlPrevious || TEXT.previous;
+    const paginationLabel = intlPaginationLabel || TEXT.defaultPaginationLabel;
 
     return tips.length > 1 ? (
       <footer class={CSS.pagination}>
@@ -303,9 +258,9 @@ export class CalciteTipManager {
   }
 
   render(): VNode {
-    const { closed, direction, groupTitle, selectedIndex, intlClose, textClose, total } = this;
+    const { closed, direction, groupTitle, selectedIndex, intlClose, total } = this;
 
-    const closeLabel = intlClose || textClose || TEXT.close;
+    const closeLabel = intlClose || TEXT.close;
 
     if (total === 0) {
       return <Host />;

--- a/src/components/calcite-tip/calcite-tip.tsx
+++ b/src/components/calcite-tip/calcite-tip.tsx
@@ -44,12 +44,6 @@ export class CalciteTip {
   @Prop() intlClose?: string;
 
   /**
-   * Alternate text for closing the tip.
-   * @deprecated use "intlClose" instead.
-   */
-  @Prop() textClose?: string;
-
-  /**
    * Used to set the component's color scheme.
    */
   @Prop({ reflect: true }) theme: CalciteTheme;
@@ -92,8 +86,8 @@ export class CalciteTip {
   // --------------------------------------------------------------------------
 
   renderHeader(): VNode {
-    const { nonDismissible, hideTip, intlClose, textClose, heading } = this;
-    const text = intlClose || textClose || TEXT.close;
+    const { nonDismissible, hideTip, intlClose, heading } = this;
+    const text = intlClose || TEXT.close;
 
     const dismissButtonNode = !nonDismissible ? (
       <calcite-action text={text} onClick={hideTip} class={CSS.close} icon={ICONS.close} />

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -20,13 +20,6 @@ export class CalciteValueListItem {
   // --------------------------------------------------------------------------
 
   /**
-   * Compact reduces the size of the item.
-   *
-   * @deprecated This property will be removed in a future release.
-   */
-  @Prop({ reflect: true }) compact? = false;
-
-  /**
    * When true, the item cannot be clicked and is visually muted
    */
   @Prop({ reflect: true }) disabled? = false;
@@ -168,7 +161,6 @@ export class CalciteValueListItem {
       <Host data-id={this.guid}>
         {this.renderHandle()}
         <calcite-pick-list-item
-          compact={this.compact}
           ref={this.getPickListRef}
           disabled={this.disabled}
           disableDeselect={this.disableDeselect}

--- a/src/components/calcite-value-list/calcite-value-list.tsx
+++ b/src/components/calcite-value-list/calcite-value-list.tsx
@@ -49,13 +49,6 @@ export class CalciteValueList<
   // --------------------------------------------------------------------------
 
   /**
-   * Compact reduces the size of all items in the list.
-   *
-   * @deprecated This property will be removed in a future release.
-   */
-  @Prop({ reflect: true }) compact = false;
-
-  /**
    * When true, disabled prevents interaction. This state shows items with lower opacity/grayed.
    */
   @Prop({ reflect: true }) disabled = false;

--- a/src/components/interfaces.ts
+++ b/src/components/interfaces.ts
@@ -1,7 +1,5 @@
 /* Note: using `.d.ts` file extension will exclude it from the output build */
 
-export type CalciteLayout = "leading" | "trailing";
-
 export type CalcitePosition = "start" | "end";
 
 export type CalciteTheme = "light" | "dark";

--- a/src/components/utils/dom.ts
+++ b/src/components/utils/dom.ts
@@ -1,5 +1,3 @@
-import { CalciteLayout, CalcitePosition } from "../interfaces";
-
 export function getElementDir(el: HTMLElement): "ltr" | "rtl" {
   return getElementProp(el, "dir", "ltr");
 }
@@ -19,16 +17,6 @@ export function focusElement(el: CalciteFocusableElement): void {
   }
 
   "setFocus" in el && typeof el.setFocus === "function" ? el.setFocus() : el.focus();
-}
-
-export function getCalcitePosition(position: CalcitePosition, layout: CalciteLayout): CalcitePosition {
-  if (position) {
-    return position;
-  }
-
-  if (layout) {
-    return layout === "trailing" ? "end" : "start";
-  }
 }
 
 interface GetSlottedOptions {

--- a/src/demos/shell/block-configurations.html
+++ b/src/demos/shell/block-configurations.html
@@ -30,7 +30,12 @@
     </style>
 
     <script>
-      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList","esri/widgets/Zoom"], function(WebMap, MapView, LayerList, Zoom) {
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList", "esri/widgets/Zoom"], function (
+        WebMap,
+        MapView,
+        LayerList,
+        Zoom
+      ) {
         const webmap = new WebMap({
           portalItem: {
             id: "cc316ca9e0824970ad29ac558161d42d"
@@ -40,9 +45,9 @@
         const view = new MapView({
           container: "viewDiv",
           map: webmap,
-          padding: {left: 49, right: 385}
+          padding: { left: 49, right: 385 }
         });
-        view.when(function() {
+        view.when(function () {
           var layerList = new LayerList({
             view: view,
             selectionEnabled: true,
@@ -61,22 +66,15 @@
           <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached detached-scale="l">
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
-                <calcite-action text="Save" icon="save" indicator>
-                </calcite-action>
-                <calcite-action icon="map" text="New">
-                </calcite-action>
-                <calcite-action icon="collection" text="Open">
-                </calcite-action>
-            </calcite-action-group>
-            <calcite-action-group>
-                <calcite-action icon="layers" text="Layers" active>
-                </calcite-action>
-                <calcite-action icon="basemap" text="Basemaps">
-                </calcite-action>
-                <calcite-action icon="legend" text="Legend">
-                </calcite-action>
-                <calcite-action icon="bookmark" text="Bookmarks">
-                </calcite-action>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action icon="map" text="New"> </calcite-action>
+                <calcite-action icon="collection" text="Open"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers" active> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
               </calcite-action-group>
               <calcite-action-group>
                 <calcite-action text="Share" icon="share"></calcite-action>
@@ -88,11 +86,11 @@
               </calcite-action-group>
             </calcite-action-bar>
             <calcite-flow>
-                <calcite-flow-item heading="Layers">
-                    <div id="layerlist-container"></div>
-                    <calcite-fab slot="fab" id="layer-fab" text="Add layers"></calcite-fab>
-                    <calcite-tooltip reference-element="layer-fab" disable-pointer>Add layers</calcite-tooltip>
-                </calcite-flow-item>
+              <calcite-flow-item heading="Layers">
+                <div id="layerlist-container"></div>
+                <calcite-fab slot="fab" id="layer-fab" text="Add layers"></calcite-fab>
+                <calcite-tooltip reference-element="layer-fab" disable-pointer>Add layers</calcite-tooltip>
+              </calcite-flow-item>
             </calcite-flow>
           </calcite-shell-panel>
 
@@ -126,189 +124,189 @@
                 heading="Configure popup"
                 summary="Popular Demographics in the United States (Beta) - County"
               >
-                
-                <calcite-block heading="Basic"  summary="Collapsible" collapsible>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="Basic" summary="Collapsible" collapsible>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block heading="Basic"  summary="Not collapsible">
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="Basic" summary="Not collapsible">
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block heading="With control"  summary="Collapsible" collapsible>
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="With control" summary="Collapsible" collapsible>
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block heading="With control"  summary="Not collapsible">
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="With control" summary="Not collapsible">
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block heading="With icon"  summary="Collapsible" collapsible>
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="With icon" summary="Collapsible" collapsible>
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block heading="With icon"  summary="Not collapsible">
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="With icon" summary="Not collapsible">
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block heading="With icon and control and long stuff"  summary="Collapsible" collapsible>
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="With icon and control and long stuff" summary="Collapsible" collapsible>
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block heading="With icon and control"  summary="Not collapsible">
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block heading="With icon and control" summary="Not collapsible">
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
-                </calcite-block>
-
-                <calcite-block drag-handle heading="Drag + Basic"  summary="Collapsible" collapsible>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
-                    </div>
-                </calcite-block>
-                <calcite-block drag-handle heading="Drag + Basic"  summary="Not collapsible">
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
-                    </div>
-                </calcite-block>
-                <calcite-block drag-handle heading="Drag + Basic with control and some extra text"  summary="Collapsible" collapsible>
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
-                    </div>
-                </calcite-block>
-                <calcite-block drag-handle heading="Drag + Basicwithcontrolandsomeextratext"  summary="Not collapsible">
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
-                    </div>
-                </calcite-block>
-                <calcite-block drag-handle heading="Drag + Basic with icon"  summary="Collapsible" collapsible>
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
-                    </div>
-                </calcite-block>
-                <calcite-block drag-handle heading="Drag + Basic with icon"  summary="Not collapsible">
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
-                    </div>
+                  </div>
                 </calcite-block>
 
-                <calcite-block drag-handle heading="Basic with icon and control"  summary="Collapsible" collapsible>
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block drag-handle heading="Drag + Basic" summary="Collapsible" collapsible>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                <calcite-block drag-handle heading="Basic with icon and control"  summary="Not collapsible">
-                    <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
-                    <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
-                    <div class="combo-control">
-                        <div class="combo-button">
-                            <button class="combo-button__main">
-                            County: {NAME}
-                            </button>
-                            <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
-                        </div>
+                <calcite-block drag-handle heading="Drag + Basic" summary="Not collapsible">
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
                     </div>
+                  </div>
                 </calcite-block>
-                
-                
+                <calcite-block
+                  drag-handle
+                  heading="Drag + Basic with control and some extra text"
+                  summary="Collapsible"
+                  collapsible
+                >
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
+                    </div>
+                  </div>
+                </calcite-block>
+                <calcite-block drag-handle heading="Drag + Basicwithcontrolandsomeextratext" summary="Not collapsible">
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
+                    </div>
+                  </div>
+                </calcite-block>
+                <calcite-block drag-handle heading="Drag + Basic with icon" summary="Collapsible" collapsible>
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
+                    </div>
+                  </div>
+                </calcite-block>
+                <calcite-block drag-handle heading="Drag + Basic with icon" summary="Not collapsible">
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
+                    </div>
+                  </div>
+                </calcite-block>
 
-
+                <calcite-block drag-handle heading="Basic with icon and control" summary="Collapsible" collapsible>
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
+                    </div>
+                  </div>
+                </calcite-block>
+                <calcite-block drag-handle heading="Basic with icon and control" summary="Not collapsible">
+                  <calcite-icon icon="title" scale="m" slot="icon"></calcite-icon>
+                  <calcite-action slot="control" icon="ellipsis" scale="m"></calcite-action>
+                  <div class="combo-control">
+                    <div class="combo-button">
+                      <button class="combo-button__main">
+                        County: {NAME}
+                      </button>
+                      <calcite-action class="combo-action" scale="s" icon="code"></calcite-action>
+                    </div>
+                  </div>
+                </calcite-block>
 
                 <calcite-fab slot="fab" id="label-fab" text="Add label class"></calcite-fab>
                 <calcite-tooltip reference-element="label-fab" disable-pointer>
@@ -318,9 +316,9 @@
             </calcite-flow>
           </calcite-shell-panel>
           <div class="gnav" slot="shell-header">
-              <h2>Cool app</h2>
+            <h2>Cool app</h2>
           </div>
-          <calcite-tip-manager slot="tip-manager" id="tip-manager" hidden>
+          <calcite-tip-manager slot="center-row" id="tip-manager" hidden>
             <calcite-tip-group text-group-title="Astronomy">
               <calcite-tip heading="The Red Rocks and Blue Water">
                 <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
@@ -406,7 +404,7 @@
       <script>
         const tipManagerButton = document.getElementById("tip-manager-button");
         const tipManager = document.getElementById("tip-manager");
-        tipManagerButton.addEventListener("click", function() {
+        tipManagerButton.addEventListener("click", function () {
           tipManager.hasAttribute("hidden")
             ? tipManager.removeAttribute("hidden")
             : tipManager.setAttribute("hidden", "");

--- a/src/demos/shell/demo-app-advanced-2.html
+++ b/src/demos/shell/demo-app-advanced-2.html
@@ -30,7 +30,7 @@
     </style>
 
     <script>
-      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList"], function(WebMap, MapView, LayerList) {
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList"], function (WebMap, MapView, LayerList) {
         const webmap = new WebMap({
           portalItem: {
             id: "cc316ca9e0824970ad29ac558161d42d"
@@ -40,13 +40,12 @@
           container: "viewDiv",
           map: webmap
         });
-        view.when(function() {
+        view.when(function () {
           var layerList = new LayerList({
             view: view,
             selectionEnabled: true,
             container: "layerlist-container"
           });
-
         });
       });
     </script>
@@ -146,7 +145,7 @@
                   <section class="form-section">
                     <label for="">
                       Label attribute
-                      <input type="text" value="2018 Total Population (Esri)">
+                      <input type="text" value="2018 Total Population (Esri)" />
                     </label>
                   </section>
                   <section class="form-section">
@@ -162,7 +161,7 @@
                     <section class="form-section">
                       <label for="">
                         Label attribute
-                        <input type="text" value="NAME">
+                        <input type="text" value="NAME" />
                       </label>
                     </section>
                     <section class="form-section">
@@ -184,7 +183,7 @@
                     <section class="form-section">
                       <label for="">
                         Label attribute
-                        <input type="text" value="2018 Total Households (Esri)">
+                        <input type="text" value="2018 Total Households (Esri)" />
                       </label>
                     </section>
                     <section class="form-section">
@@ -211,7 +210,7 @@
               <h2 class="heading">My App</h2>
             </header>
           </div>
-          <calcite-tip-manager slot="tip-manager" id="tip-manager" hidden>
+          <calcite-tip-manager slot="center-row" id="tip-manager" hidden>
             <calcite-tip-group text-group-title="Astronomy">
               <calcite-tip heading="The Red Rocks and Blue Water">
                 <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
@@ -297,7 +296,7 @@
       <script>
         const tipManagerButton = document.getElementById("tip-manager-button");
         const tipManager = document.getElementById("tip-manager");
-        tipManagerButton.addEventListener("click", function() {
+        tipManagerButton.addEventListener("click", function () {
           tipManager.hasAttribute("hidden")
             ? tipManager.removeAttribute("hidden")
             : tipManager.setAttribute("hidden", "");

--- a/src/demos/shell/demo-app-advanced-center-row.html
+++ b/src/demos/shell/demo-app-advanced-center-row.html
@@ -29,48 +29,46 @@
       }
     </style>
 
-<script>
-    require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList","esri/widgets/Zoom"], function(WebMap, MapView, LayerList, Zoom) {
-      const webmap = new WebMap({
-        portalItem: {
-          id: "cc316ca9e0824970ad29ac558161d42d"
-        }
-      });
+    <script>
+      require(["esri/WebMap", "esri/views/MapView", "esri/widgets/LayerList", "esri/widgets/Zoom"], function (
+        WebMap,
+        MapView,
+        LayerList,
+        Zoom
+      ) {
+        const webmap = new WebMap({
+          portalItem: {
+            id: "cc316ca9e0824970ad29ac558161d42d"
+          }
+        });
 
-      const view = new MapView({
-        container: "viewDiv",
-        map: webmap,
-        padding: {left: 49, right: 49}
+        const view = new MapView({
+          container: "viewDiv",
+          map: webmap,
+          padding: { left: 49, right: 49 }
+        });
+        view.when(function () {
+          view.ui.move("zoom", "bottom-right");
+        });
       });
-      view.when(function() {
-        view.ui.move("zoom", "bottom-right");
-      });
-    });
-  </script>
+    </script>
   </head>
   <body>
     <main>
       <div class="shell-container">
         <calcite-shell>
-          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start"  detached-scale="l">
+          <calcite-shell-panel id="primary-panel" slot="primary-panel" position="start" detached-scale="l">
             <calcite-action-bar slot="action-bar" theme="dark">
               <calcite-action-group>
-                <calcite-action text="Save" icon="save" indicator>
-                </calcite-action>
-                <calcite-action icon="map" text="New">
-                </calcite-action>
-                <calcite-action icon="collection" text="Open">
-                </calcite-action>
-            </calcite-action-group>
-            <calcite-action-group>
-                <calcite-action icon="layers" text="Layers" active>
-                </calcite-action>
-                <calcite-action icon="basemap" text="Basemaps">
-                </calcite-action>
-                <calcite-action icon="legend" text="Legend">
-                </calcite-action>
-                <calcite-action icon="bookmark" text="Bookmarks">
-                </calcite-action>
+                <calcite-action text="Save" icon="save" indicator> </calcite-action>
+                <calcite-action icon="map" text="New"> </calcite-action>
+                <calcite-action icon="collection" text="Open"> </calcite-action>
+              </calcite-action-group>
+              <calcite-action-group>
+                <calcite-action icon="layers" text="Layers" active> </calcite-action>
+                <calcite-action icon="basemap" text="Basemaps"> </calcite-action>
+                <calcite-action icon="legend" text="Legend"> </calcite-action>
+                <calcite-action icon="bookmark" text="Bookmarks"> </calcite-action>
               </calcite-action-group>
               <calcite-action-group>
                 <calcite-action text="Share" icon="share"></calcite-action>
@@ -82,16 +80,16 @@
               </calcite-action-group>
             </calcite-action-bar>
             <calcite-flow>
-                <calcite-flow-item heading="First flow item">
-                    Default slot of the first flow-item
-                </calcite-flow-item>
-                <calcite-flow-item heading="Second flow item 02">
-                    Default slot of the second flow-item
-                </calcite-flow-item>
+              <calcite-flow-item heading="First flow item">
+                Default slot of the first flow-item
+              </calcite-flow-item>
+              <calcite-flow-item heading="Second flow item 02">
+                Default slot of the second flow-item
+              </calcite-flow-item>
             </calcite-flow>
           </calcite-shell-panel>
 
-          <calcite-shell-panel slot="contextual-panel" position="end"  detached-scale="l">
+          <calcite-shell-panel slot="contextual-panel" position="end" detached-scale="l">
             <calcite-action-bar slot="action-bar">
               <calcite-action-group>
                 <calcite-action text="Layer properties" icon="sliders-horizontal"> </calcite-action>
@@ -117,25 +115,25 @@
               </calcite-action-group>
             </calcite-action-bar>
             <calcite-flow id="flow">
-              <calcite-flow-item
-                heading="Single flow-item"
-                summary="I'm in the contextual-panel"
-              >
+              <calcite-flow-item heading="Single flow-item" summary="I'm in the contextual-panel">
                 Default slot of flow-item
               </calcite-flow-item>
             </calcite-flow>
           </calcite-shell-panel>
           <div class="gnav" slot="shell-header">
-              <h2>Boomer v Millennial - California</h2>
+            <h2>Boomer v Millennial - California</h2>
           </div>
           <calcite-shell-center-row slot="center-row" height-scale="s" detached id="center-row">
             <calcite-panel heading="Data table" summary="US Demographics - Country - County">
               <calcite-action slot="header-leading-content" text="Switch layer" icon="caret-down"></calcite-action>
-              <calcite-action slot="header-trailing-content" text="Expand" icon="expand" id="expand-trigger"></calcite-action>
+              <calcite-action
+                slot="header-trailing-content"
+                text="Expand"
+                icon="expand"
+                id="expand-trigger"
+              ></calcite-action>
               <calcite-fab slot="fab"></calcite-fab>
-              <div class="header" slot="header-content">
-                Data table<br/>US Demographics - Country - County
-              </div>
+              <div class="header" slot="header-content">Data table<br />US Demographics - Country - County</div>
               <style>
                 .demo-table th {
                   background-color: white;
@@ -356,60 +354,59 @@
                   <td>When will you die?</td>
                   <td>Protagonist</td>
                 </tr>
-                
               </table>
-          </calcite-panel>
-        </calcite-shell-center-row>
-        <calcite-tip-manager slot="tip-manager" id="tip-manager" hidden detached>
-          <calcite-tip-group text-group-title="Astronomy">
-            <calcite-tip heading="The Red Rocks and Blue Water">
-              <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
+            </calcite-panel>
+          </calcite-shell-center-row>
+          <calcite-tip-manager slot="center-row" id="tip-manager" hidden detached>
+            <calcite-tip-group text-group-title="Astronomy">
+              <calcite-tip heading="The Red Rocks and Blue Water">
+                <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />
+                <p>
+                  This tip is how a tip should really look. It has a landscape or square image and a small amount of
+                  text content. This paragraph is in an "info" slot.
+                </p>
+                <p>
+                  This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum
+                  is a placeholder text commonly used to demonstrate the visual form of a document without relying on
+                  meaningful content (also called greeking). Replacing the actual content with placeholder text allows
+                  designers to design the form of the content before the content itself has been produced.
+                </p>
+                <a href="http://www.esri.com">This is the "link" slot.</a>
+              </calcite-tip>
+              <calcite-tip heading="The Long Trees">
+                <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
+                <p>
+                  This tip has an image that is a pretty tall. And the text will run out before the end of the image.
+                </p>
+                <p>In astronomy, the terms object and body are often used interchangeably.</p>
+                <a href="http://www.esri.com">View Esri</a>
+              </calcite-tip>
+            </calcite-tip-group>
+            <calcite-tip heading="Square Nature">
+              <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
               <p>
-                This tip is how a tip should really look. It has a landscape or square image and a small amount of
-                text content. This paragraph is in an "info" slot.
-              </p>
-              <p>
-                This is another paragraph in a subsequent "info" slot. In publishing and graphic design, Lorem ipsum
-                is a placeholder text commonly used to demonstrate the visual form of a document without relying on
-                meaningful content (also called greeking). Replacing the actual content with placeholder text allows
-                designers to design the form of the content before the content itself has been produced.
-              </p>
-              <a href="http://www.esri.com">This is the "link" slot.</a>
-            </calcite-tip>
-            <calcite-tip heading="The Long Trees">
-              <img slot="thumbnail" src="https://placeimg.com/1000/600/nature" alt="This is an image." />
-              <p>
-                This tip has an image that is a pretty tall. And the text will run out before the end of the image.
+                This tip has an image that is square. And the text will run out before the end of the image.
               </p>
               <p>In astronomy, the terms object and body are often used interchangeably.</p>
+              <p>
+                In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
+                visual form of a document without relying on meaningful content (also called greeking). Replacing the
+                actual content with placeholder text allows designers to design the form of the content before the
+                content itself has been produced.
+              </p>
               <a href="http://www.esri.com">View Esri</a>
             </calcite-tip>
-          </calcite-tip-group>
-          <calcite-tip heading="Square Nature">
-            <img slot="thumbnail" src="https://placeimg.com/1000/1000/nature" alt="This is an image." />
-            <p>
-              This tip has an image that is square. And the text will run out before the end of the image.
-            </p>
-            <p>In astronomy, the terms object and body are often used interchangeably.</p>
-            <p>
-              In publishing and graphic design, Lorem ipsum is a placeholder text commonly used to demonstrate the
-              visual form of a document without relying on meaningful content (also called greeking). Replacing the
-              actual content with placeholder text allows designers to design the form of the content before the
-              content itself has been produced.
-            </p>
-            <a href="http://www.esri.com">View Esri</a>
-          </calcite-tip>
-          <calcite-tip heading="The lack of imagery">
-            <p>
-              This tip has no image. As such, the content area will take up the entire width of the tip.
-            </p>
-            <p>
-              This is the next paragraph and should show how wide the content area is now. Of course, the width of the
-              overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
-            </p>
-            <a href="http://www.esri.com">View Esri</a>
-          </calcite-tip>
-        </calcite-tip-manager>
+            <calcite-tip heading="The lack of imagery">
+              <p>
+                This tip has no image. As such, the content area will take up the entire width of the tip.
+              </p>
+              <p>
+                This is the next paragraph and should show how wide the content area is now. Of course, the width of the
+                overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
+              </p>
+              <a href="http://www.esri.com">View Esri</a>
+            </calcite-tip>
+          </calcite-tip-manager>
           <div id="viewDiv"></div>
 
           <footer slot="shell-footer">Footer</footer>
@@ -418,7 +415,7 @@
       <script>
         const tipManagerButton = document.getElementById("tip-manager-button");
         const tipManager = document.getElementById("tip-manager");
-        tipManagerButton.addEventListener("click", function() {
+        tipManagerButton.addEventListener("click", function () {
           tipManager.hasAttribute("hidden")
             ? tipManager.removeAttribute("hidden")
             : tipManager.setAttribute("hidden", "");
@@ -426,8 +423,8 @@
 
         const expandTrigger = document.getElementById("expand-trigger");
         const centerRow = document.getElementById("center-row");
-        expandTrigger.addEventListener("click", function(){
-            centerRow.getAttribute("height-scale") == "s"
+        expandTrigger.addEventListener("click", function () {
+          centerRow.getAttribute("height-scale") == "s"
             ? centerRow.setAttribute("height-scale", "m")
             : centerRow.setAttribute("height-scale", "s");
         });

--- a/src/demos/shell/demo-app-advanced.html
+++ b/src/demos/shell/demo-app-advanced.html
@@ -282,7 +282,7 @@
           <div class="gnav" slot="shell-header">
               <h2>Boomer v Millennial - California</h2>
           </div>
-          <calcite-tip-manager slot="tip-manager" id="tip-manager" hidden>
+          <calcite-tip-manager slot="center-row" id="tip-manager" hidden>
             <calcite-tip-group text-group-title="Astronomy">
               <calcite-tip heading="The Red Rocks and Blue Water">
                 <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />

--- a/src/demos/shell/demo-app-full-window-reversed.html
+++ b/src/demos/shell/demo-app-full-window-reversed.html
@@ -352,7 +352,7 @@
               <h2 class="heading">My App</h2>
             </header>
           </div>
-          <calcite-tip-manager slot="tip-manager" id="tip-manager">
+          <calcite-tip-manager slot="center-row" id="tip-manager">
             <calcite-tip-group text-group-title="Astronomy">
               <calcite-tip heading="The Red Rocks and Blue Water">
                 <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />

--- a/src/demos/shell/demo-app-full-window.html
+++ b/src/demos/shell/demo-app-full-window.html
@@ -365,7 +365,7 @@
               <h2 class="heading">My App</h2>
             </header>
           </div>
-          <calcite-tip-manager slot="tip-manager" id="tip-manager">
+          <calcite-tip-manager slot="center-row" id="tip-manager">
             <calcite-tip-group text-group-title="Astronomy">
               <calcite-tip heading="The Red Rocks and Blue Water">
                 <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />

--- a/src/demos/shell/demo-app.html
+++ b/src/demos/shell/demo-app.html
@@ -201,7 +201,7 @@
                 <h2 class="heading">My App</h2>
               </header>
             </div>
-            <calcite-tip-manager slot="tip-manager">
+            <calcite-tip-manager slot="center-row">
               <calcite-tip-group text-group-title="Astronomy">
                 <calcite-tip heading="The Red Rocks and Blue Water">
                   <img slot="thumbnail" src="https://placeimg.com/1000/600/city" alt="This is an image." />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig-base",
   "include": [
     ".storybook/declarations.d.ts",
-    "src",
+    "./src/components",
     "node_modules/@esri/calcite-components/dist/types/components.d.ts"
   ],
   "exclude": ["**/*.stories.ts", "**/tests/**"]


### PR DESCRIPTION
**Related Issue:** None

## Summary

BREAKING CHANGE:

- Removed deprecated 'text-*' properties from action-bar, action-pad, block, block-section, filter, flow-item, panel, tip-manager, and tip.
- Removed deprecated 'layout' property from action-bar, action-pad, and shell-panel.
- Removed deprecated 'compact' property from pick-list-item, pick-list, value-list, and value-list-item.
- Removed deprecated `tip-manager` slot from shell.