### PR TITLE
docs(action-bar, action-pad): add tooltip-prop stories

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.stories.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.stories.ts
@@ -61,3 +61,24 @@ export const basic = (): string =>
     </calcite-action-group>
   `
   );
+
+export const withTooltip = (): DocumentFragment => {
+  const action = document.createElement("calcite-action");
+  action.text = "Add";
+  action.icon = "plus";
+
+  const tooltip = document.createElement("calcite-tooltip");
+  tooltip.innerText = "Expand";
+
+  const actionBar = document.createElement("calcite-action-bar");
+  actionBar.tooltipExpand = tooltip;
+
+  actionBar.append(action);
+
+  const fragment = document.createDocumentFragment();
+
+  fragment.append(actionBar);
+  fragment.append(tooltip);
+
+  return fragment;
+};

--- a/src/components/calcite-action-pad/calcite-action-pad.stories.ts
+++ b/src/components/calcite-action-pad/calcite-action-pad.stories.ts
@@ -61,3 +61,24 @@ export const basic = (): string =>
     </calcite-action-group>
   `
   );
+
+export const withTooltip = (): DocumentFragment => {
+  const action = document.createElement("calcite-action");
+  action.text = "Add";
+  action.icon = "plus";
+
+  const tooltip = document.createElement("calcite-tooltip");
+  tooltip.innerText = "Expand";
+
+  const actionPad = document.createElement("calcite-action-pad");
+  actionPad.tooltipExpand = tooltip;
+
+  actionPad.append(action);
+
+  const fragment = document.createDocumentFragment();
+
+  fragment.append(actionPad);
+  fragment.append(tooltip);
+
+  return fragment;
+};


### PR DESCRIPTION
**Related Issue:** #910

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Storybook knobs only support string, number, null and undefined as values, so it’s not possible to have one handle DOM references. This adds simple tooltip-specific stories. 
