### PR TITLE
refactor(dom): enhance getSlotted to process direct children

### DIFF
--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, Host, Listen, Prop, h } from "@stencil/core";
 import { VNode } from "@stencil/core/internal";
 import { focusElement, getElementDir, getSlotted } from "../utils/dom";
-import { BLACKLISTED_MENU_ACTIONS_COMPONENTS, CSS, ICONS, SLOTS, TEXT } from "./resources";
+import { CSS, ICONS, SLOTS, TEXT } from "./resources";
 import { SLOTS as PANEL_SLOTS } from "../calcite-panel/resources";
 import { getRoundRobinIndex } from "../utils/array";
 import { CalciteScale, CalciteTheme } from "../interfaces";
@@ -305,13 +305,8 @@ export class CalciteFlowItem {
   }
 
   renderHeaderActions(): VNode {
-    const menuActions = getSlotted(this.el, SLOTS.menuActions, { all: true });
-
-    const filteredActions = menuActions.filter(
-      (el) => !el.closest(BLACKLISTED_MENU_ACTIONS_COMPONENTS.join(","))
-    );
-
-    const actionCount = filteredActions.length;
+    const menuActions = getSlotted(this.el, SLOTS.menuActions, { all: true, direct: true });
+    const actionCount = menuActions.length;
 
     const menuActionsNodes =
       actionCount === 1

--- a/src/components/calcite-flow-item/calcite-flow-item.tsx
+++ b/src/components/calcite-flow-item/calcite-flow-item.tsx
@@ -305,7 +305,7 @@ export class CalciteFlowItem {
   }
 
   renderHeaderActions(): VNode {
-    const menuActions = getSlotted(this.el, SLOTS.menuActions, { all: true, direct: true });
+    const menuActions = getSlotted(this.el, SLOTS.menuActions, { all: true });
     const actionCount = menuActions.length;
 
     const menuActionsNodes =

--- a/src/components/calcite-flow-item/resources.ts
+++ b/src/components/calcite-flow-item/resources.ts
@@ -1,5 +1,3 @@
-export const BLACKLISTED_MENU_ACTIONS_COMPONENTS = ["calcite-pick-list", "calcite-value-list"];
-
 export const CSS = {
   header: "header-content",
   heading: "heading",

--- a/src/components/utils/dom.spec.ts
+++ b/src/components/utils/dom.spec.ts
@@ -4,6 +4,10 @@ describe("dom", () => {
   describe("getSlotted()", () => {
     const testSlotName = "test";
 
+    function getTestComponent(): HTMLElement {
+      return document.body.querySelector("slot-test");
+    }
+
     beforeAll(() => {
       class SlotTest extends HTMLElement {
         constructor() {
@@ -36,30 +40,66 @@ describe("dom", () => {
 
     describe("single slotted", () => {
       it("returns elements with matching slot name", () =>
-        expect(getSlotted(document.body, testSlotName)).toBeTruthy());
+        expect(getSlotted(getTestComponent(), testSlotName)).toBeTruthy());
 
-      it("returns null when no results", () => expect(getSlotted(document.body, "non-existent-slot")).toBeNull());
+      it("returns null when no results", () => expect(getSlotted(getTestComponent(), "non-existent-slot")).toBeNull());
 
       describe("scoped selector", () => {
         it("returns element with matching nested selector", () =>
-          expect(getSlotted(document.body, testSlotName, { selector: "span" })).toBeTruthy());
+          expect(getSlotted(getTestComponent(), testSlotName, { selector: "span" })).toBeTruthy());
 
         it("returns nothing with non-matching child selector", () =>
-          expect(getSlotted(document.body, testSlotName, { selector: "non-existent-slot" })).toBeNull());
+          expect(getSlotted(getTestComponent(), testSlotName, { selector: "non-existent-slot" })).toBeNull());
+      });
+
+      describe("direct slotted children", () => {
+        it("returns element if slot is child of element", () => {
+          document.body.innerHTML = `
+            <slot-test>
+              <h2 slot=${testSlotName}><span>😂</span></h2>
+              <some-other-element>
+                <h2 slot=${testSlotName}><span>🙃</span></h2>
+              </some-other-element>
+            </slot-test>
+          `;
+
+          expect(
+            getSlotted(getTestComponent(), testSlotName, {
+              direct: true
+            })
+          ).toBeTruthy();
+        });
+
+        it("returns null if slot is nested", () => {
+          document.body.innerHTML = `
+            <slot-test>
+              <some-other-element>
+                <h2 slot=${testSlotName}><span>🙃</span></h2>
+              </some-other-element>
+            </slot-test>
+          `;
+
+          expect(
+            getSlotted(getTestComponent(), testSlotName, {
+              all: true,
+              direct: true
+            })
+          ).toBeTruthy();
+        });
       });
     });
 
     describe("multiple slotted", () => {
       it("returns elements with matching slot name", () =>
-        expect(getSlotted(document.body, testSlotName, { all: true })).toHaveLength(2));
+        expect(getSlotted(getTestComponent(), testSlotName, { all: true })).toHaveLength(2));
 
       it("returns empty list when no results", () =>
-        expect(getSlotted(document.body, "non-existent-slot", { all: true })).toHaveLength(0));
+        expect(getSlotted(getTestComponent(), "non-existent-slot", { all: true })).toHaveLength(0));
 
       describe("scoped selector", () => {
         it("returns child elements matching selector", () =>
           expect(
-            getSlotted(document.body, testSlotName, {
+            getSlotted(getTestComponent(), testSlotName, {
               all: true,
               selector: "span"
             })
@@ -67,11 +107,49 @@ describe("dom", () => {
 
         it("returns empty list with non-matching child selector", () =>
           expect(
-            getSlotted(document.body, testSlotName, {
+            getSlotted(getTestComponent(), testSlotName, {
               all: true,
               selector: "non-existent"
             })
           ).toHaveLength(0));
+      });
+
+      describe("direct slotted children", () => {
+        it("returns child elements if children are direct descendants", () => {
+          document.body.innerHTML = `
+            <slot-test>
+              <h2 slot=${testSlotName}><span>😃</span></h2>
+              <some-other-element>
+                <h2 slot=${testSlotName}><span>🙃</span></h2>
+              </some-other-element>
+            </slot-test>
+          `;
+
+          expect(
+            getSlotted(getTestComponent(), testSlotName, {
+              all: true,
+              direct: true
+            })
+          ).toHaveLength(1);
+        });
+
+        it("returns empty list if children are nested", () => {
+          document.body.innerHTML = `
+            <slot-test>
+              <some-other-element>
+                <h2 slot=${testSlotName}><span>😃</span></h2>
+                <h2 slot=${testSlotName}><span>🙃</span></h2>
+              </some-other-element>
+            </slot-test>
+          `;
+
+          expect(
+            getSlotted(getTestComponent(), testSlotName, {
+              all: true,
+              direct: true
+            })
+          ).toHaveLength(0);
+        });
       });
     });
   });

--- a/src/components/utils/dom.ts
+++ b/src/components/utils/dom.ts
@@ -40,22 +40,36 @@ export function getSlotted<T extends Element = Element>(
   slotName: string,
   options?: GetSlottedOptions
 ): (T | null) | T[] {
-  const slottedSelector = `[slot="${slotName}"]`;
-  const selector = options?.selector ? `${slottedSelector} ${options.selector}` : slottedSelector;
+  const selector = buildSlottedSelector(slotName, options?.selector);
 
   if (options?.all) {
-    const matches = Array.from(element.querySelectorAll<T>(selector));
-    return options.direct ? direct(element, matches) : matches;
+    return queryMultiple<T>(element, selector, options?.direct);
   }
 
-  const match = element.querySelector<T>(selector);
-  return options?.direct ? direct(element, match) : match;
+  return querySingle<T>(element, selector, options?.direct);
 }
 
-function direct<T extends Element = Element>(element: Element, itemsOrItem: T | T[]): T | T[] {
-  if (Array.isArray(itemsOrItem)) {
-    return itemsOrItem.filter((item) => item.parentElement === element);
+function buildSlottedSelector(slotName: string, selector?: string): string {
+  const slottedSelector = `[slot="${slotName}"]`;
+  return selector ? `${slottedSelector} ${selector}` : slottedSelector;
+}
+
+function queryMultiple<T extends Element = Element>(element: Element, selector: string, direct?: boolean): T[] {
+  const items = Array.from(element.querySelectorAll<T>(selector));
+
+  if (!direct) {
+    return items;
   }
 
-  return itemsOrItem.parentElement === element ? itemsOrItem : null;
+  return items.filter((item) => item.parentElement === element);
+}
+
+function querySingle<T extends Element = Element>(element: Element, selector: string, direct?: boolean): T | null {
+  const match = element.querySelector<T>(selector);
+
+  if (!direct) {
+    return match;
+  }
+
+  return match?.parentElement === element ? match : null;
 }

--- a/src/components/utils/dom.ts
+++ b/src/components/utils/dom.ts
@@ -40,36 +40,35 @@ export function getSlotted<T extends Element = Element>(
   slotName: string,
   options?: GetSlottedOptions
 ): (T | null) | T[] {
-  const selector = buildSlottedSelector(slotName, options?.selector);
+  const slotSelector = `[slot="${slotName}"]`;
 
   if (options?.all) {
-    return queryMultiple<T>(element, selector, options?.direct);
+    return queryMultiple<T>(element, slotSelector, options);
   }
 
-  return querySingle<T>(element, selector, options?.direct);
+  return querySingle<T>(element, slotSelector, options);
 }
 
-function buildSlottedSelector(slotName: string, selector?: string): string {
-  const slottedSelector = `[slot="${slotName}"]`;
-  return selector ? `${slottedSelector} ${selector}` : slottedSelector;
+function queryMultiple<T extends Element = Element>(
+  element: Element,
+  slotSelector: string,
+  options?: GetSlottedOptions
+): T[] {
+  let matches = Array.from(element.querySelectorAll<T>(slotSelector));
+  matches = options?.direct ? matches.filter((el) => el.parentElement === element) : matches;
+
+  const selector = options?.selector;
+  return selector ? matches.map((item) => item.querySelector<T>(selector)).filter((match) => !!match) : matches;
 }
 
-function queryMultiple<T extends Element = Element>(element: Element, selector: string, direct?: boolean): T[] {
-  const items = Array.from(element.querySelectorAll<T>(selector));
+function querySingle<T extends Element = Element>(
+  element: Element,
+  slotSelector: string,
+  options?: GetSlottedOptions
+): T | null {
+  let match = element.querySelector<T>(slotSelector);
+  match = options?.direct ? (match?.parentElement === element ? match : null) : match;
 
-  if (!direct) {
-    return items;
-  }
-
-  return items.filter((item) => item.parentElement === element);
-}
-
-function querySingle<T extends Element = Element>(element: Element, selector: string, direct?: boolean): T | null {
-  const match = element.querySelector<T>(selector);
-
-  if (!direct) {
-    return match;
-  }
-
-  return match?.parentElement === element ? match : null;
+  const selector = options?.selector;
+  return selector ? match.querySelector<T>(selector) : match;
 }

--- a/src/components/utils/dom.ts
+++ b/src/components/utils/dom.ts
@@ -21,6 +21,7 @@ export function focusElement(el: CalciteFocusableElement): void {
 
 interface GetSlottedOptions {
   all?: boolean;
+  direct?: boolean;
   selector?: string;
 }
 
@@ -43,8 +44,18 @@ export function getSlotted<T extends Element = Element>(
   const selector = options?.selector ? `${slottedSelector} ${options.selector}` : slottedSelector;
 
   if (options?.all) {
-    return Array.from(element.querySelectorAll<T>(selector));
+    const matches = Array.from(element.querySelectorAll<T>(selector));
+    return options.direct ? direct(element, matches) : matches;
   }
 
-  return element.querySelector<T>(selector);
+  const match = element.querySelector<T>(selector);
+  return options?.direct ? direct(element, match) : match;
+}
+
+function direct<T extends Element = Element>(element: Element, itemsOrItem: T | T[]): T | T[] {
+  if (Array.isArray(itemsOrItem)) {
+    return itemsOrItem.filter((item) => item.parentElement === element);
+  }
+
+  return itemsOrItem.parentElement === element ? itemsOrItem : null;
 }

--- a/src/components/utils/dom.ts
+++ b/src/components/utils/dom.ts
@@ -55,7 +55,7 @@ function queryMultiple<T extends Element = Element>(
   options?: GetSlottedOptions
 ): T[] {
   let matches = Array.from(element.querySelectorAll<T>(slotSelector));
-  matches = options?.direct ? matches.filter((el) => el.parentElement === element) : matches;
+  matches = options && options.direct === false ? matches : matches.filter((el) => el.parentElement === element);
 
   const selector = options?.selector;
   return selector ? matches.map((item) => item.querySelector<T>(selector)).filter((match) => !!match) : matches;
@@ -67,7 +67,7 @@ function querySingle<T extends Element = Element>(
   options?: GetSlottedOptions
 ): T | null {
   let match = element.querySelector<T>(slotSelector);
-  match = options?.direct ? (match?.parentElement === element ? match : null) : match;
+  match = options && options.direct === false ? match : match?.parentElement === element ? match : null;
 
   const selector = options?.selector;
   return selector ? match.querySelector<T>(selector) : match;


### PR DESCRIPTION
**Related Issue:** #498

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

Since slotted elements come from light DOM and only direct children are allowed to be slotted into an element (no nesting), this adds a property to the `getSlotted` options to only process direct children (true by default). 


