### PR TITLE
chore(standard-version): use changelogHeader replacement

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,5 +1,5 @@
 {
-  "changelogHeader": "# Changelog\n\nThis document maintains a list of released versions and changes introduced by those versions.\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)\n",
+  "header": "# Changelog\n\nThis document maintains a list of released versions and changes introduced by those versions.\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)\n",
   "skip": {
     "bump": true,
     "changelog": false,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This addresses the following warning:

```
[standard-version]: --changelogHeader will be removed in the next major release. Use --header.
```