### PR TITLE
docs(pick-list): add story for nested items

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.stories.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.stories.ts
@@ -86,3 +86,39 @@ export const grouped = (): string =>
     </calcite-pick-list-group>
   `
   );
+
+export const nested = (): string =>
+  create(
+    "calcite-pick-list",
+    createAttributes(),
+    dedent`
+    <calcite-pick-list-group>
+      <calcite-pick-list-item text-label="All the dogs" value="all-dogs" slot="parent-item">
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item text-label="Husky" value="husky">
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item text-label="Pomeranian" value="pom">
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item text-label="Xoloitzcuintle" value="xolo">
+        ${action}
+      </calcite-pick-list-item>
+    </calcite-pick-list-group>
+    <calcite-pick-list-group>
+      <calcite-pick-list-item text-label="All the cats" value="all-cats" slot="parent-item">
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item text-label="Himalayan" value="himalayan">
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item text-label="Persian" value="persian">
+        ${action}
+      </calcite-pick-list-item>
+      <calcite-pick-list-item text-label="Spynx" value="spynx">
+        ${action}
+      </calcite-pick-list-item>
+    </calcite-pick-list-group>
+  `
+  );


### PR DESCRIPTION
**Related Issue:** #965 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This adds a story to demonstrate how to nest pick list items.

<img width="215" alt="Screen Shot 2020-05-29 at 11 40 21 AM" src="https://user-images.githubusercontent.com/197440/83294197-c54a2a00-a1a1-11ea-8af9-aa66d23bd699.png">
