### PR TITLE
fix(value-list): ensure keyboard-enabled DND stays active when moving items around

### DIFF
--- a/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
+++ b/src/components/calcite-pick-list-item/calcite-pick-list-item.tsx
@@ -48,7 +48,7 @@ export class CalcitePickListItem {
   /**
    * Used to provide additional metadata to an item, primarily used when the parent list has a filter.
    */
-  @Prop() metadata?: object;
+  @Prop() metadata?: Record<string, unknown>;
 
   @Watch("metadata")
   metadataWatchHandler(): void {

--- a/src/components/calcite-pick-list/calcite-pick-list.tsx
+++ b/src/components/calcite-pick-list/calcite-pick-list.tsx
@@ -24,7 +24,8 @@ import {
   selectSiblings,
   setUpItems,
   keyDownHandler,
-  setFocus
+  setFocus,
+  ItemData
 } from "./shared-list-logic";
 import List from "./shared-list-render";
 
@@ -82,7 +83,7 @@ export class CalcitePickList<
 
   @State() selectedValues: Map<string, ItemElement> = new Map();
 
-  @State() dataForFilter: object[] = [];
+  @State() dataForFilter: ItemData = [];
 
   items: ItemElement[];
 
@@ -170,7 +171,7 @@ export class CalcitePickList<
   // --------------------------------------------------------------------------
 
   @Method()
-  async getSelectedItems(): Promise<Map<string, object>> {
+  async getSelectedItems(): Promise<Map<string, HTMLCalcitePickListItemElement>> {
     return this.selectedValues;
   }
 

--- a/src/components/calcite-pick-list/shared-list-logic.ts
+++ b/src/components/calcite-pick-list/shared-list-logic.ts
@@ -243,9 +243,14 @@ export function handleFilter<T extends Lists>(this: List<T>, event: CustomEvent)
   });
 }
 
-export function getItemData<T extends Lists>(
-  this: List<T>
-): { label: string; description: string; metadata: object; value: string }[] {
+export type ItemData = {
+  label: string;
+  description: string;
+  metadata: Record<string, unknown>;
+  value: string;
+}[];
+
+export function getItemData<T extends Lists>(this: List<T>): ItemData {
   return (this.items as ListItemElement<T>[]).map((item) => ({
     label: item.textLabel,
     description: item.textDescription,

--- a/src/components/calcite-pick-list/shared-list-tests.ts
+++ b/src/components/calcite-pick-list/shared-list-tests.ts
@@ -2,6 +2,7 @@ import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { JSEvalable } from "puppeteer";
 
 type ListType = "pick" | "value";
+type ListElement = HTMLCalcitePickListElement | HTMLCalciteValueListElement;
 
 export function keyboardNavigation(listType: ListType): void {
   const getFocusedItemValue = (page: E2EPage): ReturnType<JSEvalable["evaluate"]> =>
@@ -159,13 +160,10 @@ export function selectionAndDeselection(listType: ListType): void {
           <calcite-${listType}-list-item value="two" text-label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>`);
 
-      const numSelected = await page.evaluate((listType) => {
-        const list: HTMLCalcitePickListElement | HTMLCalciteValueListElement = document.querySelector(
-          `calcite-${listType}-list`
-        );
-        return list.getSelectedItems().then((result) => {
-          return result.size;
-        });
+      const numSelected = await page.evaluate(async (listType) => {
+        const list: ListElement = document.querySelector(`calcite-${listType}-list`);
+
+        return (await list.getSelectedItems()).size;
       }, listType);
 
       expect(numSelected).toBe(1);
@@ -190,13 +188,9 @@ export function selectionAndDeselection(listType: ListType): void {
       await item3.click();
       await page.keyboard.up("Shift");
 
-      const numSelected = await page.evaluate((listType) => {
-        const list: HTMLCalcitePickListElement | HTMLCalciteValueListElement = document.querySelector(
-          `calcite-${listType}-list`
-        );
-        return list.getSelectedItems().then((result) => {
-          return result.size;
-        });
+      const numSelected = await page.evaluate(async (listType) => {
+        const list: ListElement = document.querySelector(`calcite-${listType}-list`);
+        return (await list.getSelectedItems()).size;
       }, listType);
 
       expect(numSelected).toBe(3);
@@ -218,13 +212,9 @@ export function selectionAndDeselection(listType: ListType): void {
       await item3.click();
       await page.keyboard.up("Shift");
 
-      const numSelected = await page.evaluate((type) => {
-        const domList: HTMLCalcitePickListElement | HTMLCalciteValueListElement = document.querySelector(
-          `calcite-${type}-list`
-        );
-        return domList.getSelectedItems().then((result) => {
-          return result.size;
-        });
+      const numSelected = await page.evaluate(async (type) => {
+        const domList: ListElement = document.querySelector(`calcite-${type}-list`);
+        return (await domList.getSelectedItems()).size;
       }, listType);
       expect(numSelected).toBe(0);
     });
@@ -275,13 +265,9 @@ export function selectionAndDeselection(listType: ListType): void {
       const item1 = await list.find("[value=one]");
       await item1.click();
 
-      const hasValueOne = await page.evaluate((type) => {
-        const pageList: HTMLCalcitePickListElement | HTMLCalciteValueListElement = document.querySelector(
-          `calcite-${type}-list`
-        );
-        return pageList.getSelectedItems().then((result) => {
-          return result.has("one");
-        });
+      const hasValueOne = await page.evaluate(async (type) => {
+        const pageList: ListElement = document.querySelector(`calcite-${type}-list`);
+        return (await pageList.getSelectedItems()).has("one");
       }, listType);
 
       expect(hasValueOne).toBe(true);
@@ -289,16 +275,14 @@ export function selectionAndDeselection(listType: ListType): void {
       item1.setProperty("value", "four");
       await page.waitForChanges();
 
-      const hasValues = await page.evaluate((type) => {
-        const pageList: HTMLCalcitePickListElement | HTMLCalciteValueListElement = document.querySelector(
-          `calcite-${type}-list`
-        );
-        return pageList.getSelectedItems().then((result) => {
-          return {
-            four: result.has("four"),
-            one: result.has("one")
-          };
-        });
+      const hasValues = await page.evaluate(async (type) => {
+        const pageList: ListElement = document.querySelector(`calcite-${type}-list`);
+        const result = await pageList.getSelectedItems();
+
+        return {
+          four: result.has("four"),
+          one: result.has("one")
+        };
       }, listType);
 
       expect(hasValues.one).toBe(false);

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -42,7 +42,7 @@ export class CalciteValueListItem {
   /**
    * Used to provide additional metadata to an item, primarily used when the parent list has a filter.
    */
-  @Prop() metadata?: object;
+  @Prop() metadata?: Record<string, unknown>;
 
   /**
    * Set this to true to display a remove action that removes the item from the list.
@@ -115,7 +115,7 @@ export class CalciteValueListItem {
   //
   // --------------------------------------------------------------------------
 
-  getPickListRef = (el): HTMLCalcitePickListItemElement => (this.pickListItem = el);
+  getPickListRef = (el: HTMLCalcitePickListItemElement) => (this.pickListItem = el);
 
   handleKeyDown = (event: KeyboardEvent): void => {
     if (event.key === " ") {

--- a/src/components/calcite-value-list-item/calcite-value-list-item.tsx
+++ b/src/components/calcite-value-list-item/calcite-value-list-item.tsx
@@ -115,7 +115,7 @@ export class CalciteValueListItem {
   //
   // --------------------------------------------------------------------------
 
-  getPickListRef = (el: HTMLCalcitePickListItemElement) => (this.pickListItem = el);
+  getPickListRef = (el): HTMLCalcitePickListItemElement => (this.pickListItem = el);
 
   handleKeyDown = (event: KeyboardEvent): void => {
     if (event.key === " ") {

--- a/src/components/calcite-value-list/calcite-value-list.e2e.ts
+++ b/src/components/calcite-value-list/calcite-value-list.e2e.ts
@@ -93,13 +93,28 @@ describe("calcite-value-list", () => {
     });
 
     it("works using a keyboard", async () => {
-      page.keyboard.press("Tab");
-      page.keyboard.press("Space");
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Space");
       await page.waitForChanges();
-      page.keyboard.press("ArrowDown");
-      const itemsAfter = await page.findAll("calcite-value-list-item");
-      expect(await itemsAfter[0].getProperty("value")).toBe("two");
-      expect(await itemsAfter[1].getProperty("value")).toBe("one");
+
+      async function assertKeyboardMove(direction: "down" | "up", expectedValueOrder: string[]): Promise<void> {
+        const arrowKey = `Arrow${direction.charAt(0).toUpperCase() + direction.slice(1)}`;
+        await page.keyboard.press(arrowKey);
+        await page.waitForChanges();
+        const itemsAfter = await page.findAll("calcite-value-list-item");
+
+        for (let i = 0; i < itemsAfter.length; i++) {
+          expect(await itemsAfter[i].getProperty("value")).toBe(expectedValueOrder[i]);
+        }
+      }
+
+      await assertKeyboardMove("down", ["two", "one", "three"]);
+      await assertKeyboardMove("down", ["two", "three", "one"]);
+      await assertKeyboardMove("down", ["one", "two", "three"]);
+
+      await assertKeyboardMove("up", ["two", "three", "one"]);
+      await assertKeyboardMove("up", ["two", "one", "three"]);
+      await assertKeyboardMove("up", ["one", "two", "three"]);
     });
   });
 });


### PR DESCRIPTION
**Related Issue:** #986 

## Summary

This ensures the handle element is focused right after browser rendering.

Additionally, this also fixes some ESLint errors and adds more assertions to test keyboard item-moving.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
