### PR TITLE
fix(action-bar): Sync expanded state with new children

### DIFF
--- a/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
+++ b/src/components/calcite-action-bar/calcite-action-bar.e2e.ts
@@ -113,6 +113,28 @@ describe("calcite-action-bar", () => {
 
       expect(textEnabled).toBe(false);
     });
+
+    it("should modify textEnabled on actions when expanded is true and new children are added", async () => {
+      const page = await newE2EPage();
+
+      await page.setContent(
+        `<calcite-action-bar expand expanded><calcite-action text="hello"></calcite-action></calcite-action-bar>`
+      );
+
+      await page.evaluate(() => {
+        const actionBar = document.querySelector("calcite-action-bar");
+        const newAction = document.createElement("calcite-action");
+        newAction.textEnabled = false;
+        newAction.id = "new-child";
+        actionBar.appendChild(newAction);
+      });
+
+      const action = await page.find("#new-child");
+
+      const textEnabled = await action.getProperty("textEnabled");
+
+      expect(textEnabled).toBe(true);
+    });
   });
 
   it("should be accessible", async () =>

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -111,6 +111,15 @@ export class CalciteActionBar {
     if (expand) {
       toggleChildActionText({ parent: el, expanded });
     }
+
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === "childList") {
+          toggleChildActionText({ parent: el, expanded });
+        }
+      }
+    });
+    observer.observe(el, { childList: true });
   }
 
   // --------------------------------------------------------------------------

--- a/src/components/calcite-action-bar/calcite-action-bar.tsx
+++ b/src/components/calcite-action-bar/calcite-action-bar.tsx
@@ -99,6 +99,11 @@ export class CalciteActionBar {
 
   @Element() el: HTMLCalciteActionBarElement;
 
+  observer = new MutationObserver(() => {
+    const { el, expanded } = this;
+    toggleChildActionText({ parent: el, expanded });
+  });
+
   // --------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -112,14 +117,11 @@ export class CalciteActionBar {
       toggleChildActionText({ parent: el, expanded });
     }
 
-    const observer = new MutationObserver((mutationsList) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          toggleChildActionText({ parent: el, expanded });
-        }
-      }
-    });
-    observer.observe(el, { childList: true });
+    this.observer.observe(el, { childList: true });
+  }
+
+  componentDidUnload(): void {
+    this.observer.disconnect();
   }
 
   // --------------------------------------------------------------------------

--- a/src/demos/action-bar/add-action-after-init.html
+++ b/src/demos/action-bar/add-action-after-init.html
@@ -47,6 +47,25 @@
                   }, 2000);
                 </script>
               </section>
+
+              <section>
+                <h3>Expanded</h3>
+                <calcite-action-bar id="slot-test-expanded" expanded>
+                  <calcite-action text="Add" icon="plus"> </calcite-action>
+                  <calcite-action text="Save" icon="save"> </calcite-action>
+                </calcite-action-bar>
+
+                <script>
+                  const expandedTestNode = document.getElementById("slot-test-expanded");
+                  setTimeout(function () {
+                    const action = document.createElement("calcite-action");
+                    action.setAttribute("slot", "bottom-actions");
+                    action.setAttribute("text", "Hello world");
+                    action.setAttribute("icon", "layers");
+                    expandedTestNode.appendChild(action);
+                  }, 2000);
+                </script>
+              </section>
             </div>
           </section>
         </div>


### PR DESCRIPTION
**Related Issue:** #1023 

## Summary
Adds a MutationObserver to action-bar to watch for new children and enforces the current `expanded` state to them. Tried to replicate the usage of MutationObserver from other components.

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [x] changes have been tested with demo page in Edge
-->
