### PR TITLE
fix(pick-list): hide non-nested groups that do not match filter

### DIFF
--- a/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
+++ b/src/components/calcite-pick-list/calcite-pick-list.e2e.ts
@@ -5,6 +5,7 @@ import { selectionAndDeselection, filterBehavior, disabledStates, keyboardNaviga
 
 describe("calcite-pick-list", () => {
   it("renders", async () => renders("calcite-pick-list"));
+
   it("honors hidden attribute", async () => hidden("calcite-pick-list"));
 
   it("is accessible", async () =>
@@ -12,9 +13,7 @@ describe("calcite-pick-list", () => {
       `<calcite-pick-list><calcite-pick-list-item text-label="Sample" value="one"></calcite-pick-list-item></calcite-pick-list>`
     ));
 
-  describe("Selection and Deselection", () => {
-    selectionAndDeselection("pick");
-  });
+  describe("Selection and Deselection", () => selectionAndDeselection("pick"));
 
   describe("Keyboard navigation", () => keyboardNavigation("pick"));
 
@@ -29,6 +28,7 @@ describe("calcite-pick-list", () => {
       const icon = await item.getProperty("icon");
       expect(icon).toBe(ICON_TYPES.circle);
     });
+
     it("should be 'square' when multi-select is enabled", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-pick-list multiple>
@@ -43,46 +43,102 @@ describe("calcite-pick-list", () => {
 
   describe("filter behavior (hide/show items)", () => {
     filterBehavior("pick");
+
+    let page: E2EPage = null;
+    let groupOrParentItem: E2EElement;
+    let item1: E2EElement;
+    let item2: E2EElement;
+
+    async function assertGroupIsVisibleWhenChildMatches(
+      page: E2EPage,
+      groupOrParentItem: E2EElement,
+      item1: E2EElement,
+      item2: E2EElement
+    ): Promise<void> {
+      const item1ValueLowercased = (await item1.getProperty("textLabel")).toLowerCase();
+
+      await page.evaluate(
+        (filterText) => {
+          const filterInput = (window as any).filterInput;
+          filterInput.value = filterText;
+          filterInput.dispatchEvent(new Event("input"));
+        },
+        [item1ValueLowercased]
+      );
+
+      await item2.waitForNotVisible();
+
+      const parentVisible = await groupOrParentItem.isVisible();
+
+      expect(parentVisible).toBe(true);
+    }
+
     describe("filtering with groups", () => {
-      let page: E2EPage = null;
-      let parentItem: E2EElement;
-      let item1: E2EElement;
-      let item2: E2EElement;
       beforeEach(async () => {
-        page = await newE2EPage();
-        await page.setContent(`<calcite-pick-list filter-enabled>
-          <calcite-pick-list-group>
-            <calcite-pick-list-item slot="parent-item" value="nums" text-label="Numbers"></calcite-pick-list-item>
+        page = await newE2EPage({
+          html: `<calcite-pick-list filter-enabled>
+          <calcite-pick-list-group text-group-title="Numbers">
             <calcite-pick-list-item value="1" text-label="One" text-description="uno"></calcite-pick-list-item>
             <calcite-pick-list-item value="2" text-label="Two" text-description="dos"></calcite-pick-list-item>
           </calcite-pick-list-group>
-        </calcite-pick-list>`);
-        parentItem = await page.find(`calcite-pick-list-item[slot="parent-item"]`);
+        </calcite-pick-list>`
+        });
+
+        groupOrParentItem = await page.find(`calcite-pick-list-group`);
         item1 = await page.find(`calcite-pick-list-item[value="1"]`);
         item2 = await page.find(`calcite-pick-list-item[value="2"]`);
+
         item1.setProperty("metadata", { category: "first" });
         item2.setProperty("metadata", { category: "second" });
+
         await page.waitForChanges();
         await page.evaluate(() => {
           (window as any).filter = document
             .querySelector(`calcite-pick-list`)
             .shadowRoot.querySelector("calcite-filter");
+
           const filter = (window as any).filter;
           (window as any).filterInput = filter.shadowRoot.querySelector("input");
         });
       });
-      it("should show the group parent if a match is found in a child", async () => {
-        await page.evaluate(() => {
-          const filterInput = (window as any).filterInput;
-          filterInput.value = "one";
-          filterInput.dispatchEvent(new Event("input"));
+
+      it("should show the group parent if a match is found in a child", async () =>
+        await assertGroupIsVisibleWhenChildMatches(page, groupOrParentItem, item1, item2));
+    });
+
+    describe("filtering with groups (nested)", () => {
+      beforeEach(async () => {
+        page = await newE2EPage({
+          html: `<calcite-pick-list filter-enabled>
+          <calcite-pick-list-group>
+            <calcite-pick-list-item slot="parent-item" value="nums" text-label="Numbers"></calcite-pick-list-item>
+            <calcite-pick-list-item value="1" text-label="One" text-description="uno"></calcite-pick-list-item>
+            <calcite-pick-list-item value="2" text-label="Two" text-description="dos"></calcite-pick-list-item>
+          </calcite-pick-list-group>
+        </calcite-pick-list>`
         });
-        await item2.waitForNotVisible();
 
-        const parentVisible = await parentItem.isVisible();
+        groupOrParentItem = await page.find(`calcite-pick-list-item[slot="parent-item"]`);
+        item1 = await page.find(`calcite-pick-list-item[value="1"]`);
+        item2 = await page.find(`calcite-pick-list-item[value="2"]`);
 
-        expect(parentVisible).toBe(true);
+        item1.setProperty("metadata", { category: "first" });
+        item2.setProperty("metadata", { category: "second" });
+
+        await page.waitForChanges();
+        await page.evaluate(() => {
+          (window as any).filter = document
+            .querySelector(`calcite-pick-list`)
+            .shadowRoot.querySelector("calcite-filter");
+
+          const filter = (window as any).filter;
+          (window as any).filterInput = filter.shadowRoot.querySelector("input");
+        });
       });
+
+      it("should show the group parent if a match is found in a child", async () =>
+        await assertGroupIsVisibleWhenChildMatches(page, groupOrParentItem, item1, item2));
+
       it("should show the children of a group if the parent matches", async () => {
         await page.evaluate(() => {
           const filterInput = (window as any).filterInput;
@@ -100,7 +156,5 @@ describe("calcite-pick-list", () => {
     });
   });
 
-  describe("disabled states", () => {
-    disabledStates("pick");
-  });
+  describe("disabled states", () => disabledStates("pick"));
 });


### PR DESCRIPTION
**Related Issue:** #1026 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This ensures that non-matching groups during filtering, whether nested (`slot=parent-item`) or not, are properly hidden.

cc @kevindoshier 