### PR TITLE
docs(changelog): ensure changelog includes entries from prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "prettier": "concurrently npm:prettier:*",
     "prettier:ts": "prettier --write \"src/**/*.ts?(x)\"",
     "prettier:styles": "prettier --write \"src/**/*.scss\"",
-    "previewChangelog": "standard-version --no-skip.bump --silent && cat CHANGELOG.md && git reset --hard --quiet",
-    "previewChangelog:latest": "npx touch __CHANGELOG-PREVIEW-TEMP__ && standard-version --no-skip.bump --release-count 1 --infile __CHANGELOG-PREVIEW-TEMP__ --same-file --silent && cat __CHANGELOG-PREVIEW-TEMP__ && rimraf __CHANGELOG-PREVIEW-TEMP__ && git reset --hard --quiet",
+    "previewChangelog": "ts-node ./support/ensureNonPrereleaseChangelog.ts --no-skip.bump --silent && cat CHANGELOG.md && git reset --hard --quiet",
+    "previewChangelog:latest": "npx touch __CHANGELOG-PREVIEW-TEMP__ && ts-node ./support/ensureNonPrereleaseChangelog.ts --no-skip.bump --release-count 1 --infile __CHANGELOG-PREVIEW-TEMP__ --same-file --silent && cat __CHANGELOG-PREVIEW-TEMP__ && rimraf __CHANGELOG-PREVIEW-TEMP__ && git reset --hard --quiet",
     "release": "npm run util:pushTags && npm publish && ts-node ./support/githubReleaseFromChangelog.ts",
     "release:next": "npm run util:cleanTestedBuild && npm run util:deployNextFromExistingBuild",
     "start": "concurrently --kill-others --raw \"npm run demoPageSync\" \"tsc --project ./tsconfig-demos.json --watch\" \"stencil build --dev --watch --serve\"",
@@ -41,7 +41,7 @@
     "util:prepNextFromExistingBuild": "standard-version --no-skip.bump --no-skip.commit --no-skip.tag --skip.changelog --prerelease beta",
     "util:pushTags": "git push --follow-tags",
     "util:publishNext": "npm publish --tag next",
-    "version": "npm run util:cleanTestedBuild && npm run docs && standard-version && git add ."
+    "version": "npm run util:cleanTestedBuild && npm run docs && ts-node ./support/ensureNonPrereleaseChangelog.ts && git add ."
   },
   "repository": {
     "type": "git",

--- a/support/ensureNonPrereleaseChangelog.ts
+++ b/support/ensureNonPrereleaseChangelog.ts
@@ -1,0 +1,43 @@
+const childProcess = require("child_process");
+
+// this command will pass through standard-version args
+const standardVersionOverrides = process.argv.slice(2).join(" ");
+
+const previousReleasedTag = childProcess.execSync("git describe --abbrev=0", { encoding: "utf-8" }).trim();
+const prereleaseVersionPattern = /-beta\.\d+$/;
+const previousReleaseIsPrerelease = prereleaseVersionPattern.test(previousReleasedTag);
+
+if (!previousReleaseIsPrerelease) {
+  // using process to generate changelog (auto loads .versionrc.json)
+  childProcess.execSync(`npx standard-version ${standardVersionOverrides}`, { stdio: "inherit" });
+  process.exit();
+}
+
+const latestRelease = previousReleasedTag.replace(prereleaseVersionPattern, "");
+const tempBranchName = "__temp-for-non-prerelease-changelog__";
+
+try {
+  // create a temp branch from the previous release
+  // with all commit messages without prerelease tags
+  // to omit them from the changelog
+  childProcess.execSync(`git stash push -m ${tempBranchName}`);
+  childProcess.execSync(`git checkout -b ${tempBranchName} ${latestRelease} --quiet`);
+  childProcess.execSync(`git cherry-pick ${latestRelease}..master`);
+
+  const [firstStashEntry] = childProcess.execSync(`git stash list`, { encoding: "utf-8" }).split("\n");
+  const hasOurStash = firstStashEntry.includes(tempBranchName);
+
+  if (hasOurStash) {
+    childProcess.execSync(`git stash pop`);
+  }
+
+  // using process to generate changelog (auto loads .versionrc.json)
+  childProcess.execSync(`npx standard-version ${standardVersionOverrides}`, { stdio: "inherit" });
+} catch (error) {
+  console.log("an error occurred when generating the changelog:", error);
+}
+
+childProcess.execSync(`git checkout master --quiet`);
+childProcess.execSync(`git branch -D ${tempBranchName}`);
+
+process.exit();


### PR DESCRIPTION
**Related Issue:** #1029 

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This adds a new support script to that will help create a changelog without any prerelease tags in between versions. 