### PR TITLE
build(deps): bump versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3174,13 +3174,14 @@
       "integrity": "sha512-LT6nA6HrVB9j53Du1O+WuKK1stoGVVxHCeO9RKKUgYDHDcvnzSNBwNyn95hzQzEgSoeoD8MOu7jxSn6TplAQuw=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.34.tgz",
-      "integrity": "sha512-0yGLrZyOydKjL5a8Og7S2fZCnlB+wjXQqSnZ+Y4kIp0ngazUqHfYAG1uhE5Q/j1aFi1SDszuoSMbpkoUfkkx3Q==",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.35.tgz",
+      "integrity": "sha512-tVEigCp0CK8DoJ1AycP1UeUK5VYMyRx4fkwGD13cK4LcJ9TKoX2qdiAe6gzhc3gbbSwjHl6z422BJQTzqCkAhw==",
       "dev": true,
       "requires": {
         "@a11y/focus-trap": "git+https://github.com/patrickarlt/focus-trap.git#conditional-define-build",
-        "@popperjs/core": "^2.4.4"
+        "@popperjs/core": "^2.4.4",
+        "@types/color": "3.0.1"
       }
     },
     "@icons/material": {
@@ -5524,6 +5525,24 @@
       "resolved": "https://registry.npmjs.org/@types/browserslist/-/browserslist-4.8.0.tgz",
       "integrity": "sha512-4PyO9OM08APvxxo1NmQyQKlJdowPCOQIy5D/NLO3aO0vGC57wsMptvGp3b8IbYnupFZr92l1dlVief1JvS6STQ==",
       "dev": true
+    },
+    "@types/color": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.1.tgz",
+      "integrity": "sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==",
+      "dev": true,
+      "requires": {
+        "@types/color-convert": "*"
+      }
+    },
+    "@types/color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "*"
+      }
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "sortablejs": "1.10.2"
   },
   "devDependencies": {
-    "@esri/calcite-components": "1.0.0-beta.34",
+    "@esri/calcite-components": "1.0.0-beta.35",
     "@stencil/core": "1.17.2",
     "@stencil/eslint-plugin": "0.3.1",
     "@stencil/postcss": "1.0.1",
@@ -120,7 +120,7 @@
     "updtr": "3.1.0"
   },
   "peerDependencies": {
-    "@esri/calcite-components": "1.0.0-beta.34"
+    "@esri/calcite-components": "1.0.0-beta.35"
   },
   "license": "UNLICENSED"
 }


### PR DESCRIPTION
Updates `calcite-components` to latest for a type fix.