### PR TITLE
fix(panel): remove slot-container and associated styles

### DIFF
--- a/src/components/calcite-panel/calcite-panel.scss
+++ b/src/components/calcite-panel/calcite-panel.scss
@@ -124,9 +124,3 @@ calcite-scrim {
   left: 0;
   right: 0;
 }
-
-.slot-container {
-  height: 100%;
-  position: relative;
-  z-index: 0;
-}

--- a/src/components/calcite-panel/calcite-panel.tsx
+++ b/src/components/calcite-panel/calcite-panel.tsx
@@ -222,9 +222,7 @@ export class CalcitePanel {
   renderContent(): VNode {
     return (
       <section tabIndex={0} class={CSS.contentContainer} onScroll={this.panelScrollHandler}>
-        <div class={CSS.slotContainer}>
-          <slot />
-        </div>
+        <slot />
         {this.renderFab()}
       </section>
     );

--- a/src/components/calcite-panel/resources.ts
+++ b/src/components/calcite-panel/resources.ts
@@ -6,7 +6,6 @@ export const CSS = {
   headerTrailingContent: "header-trailing-content",
   contentContainer: "content-container",
   fabContainer: "fab-container",
-  slotContainer: "slot-container",
   footer: "footer"
 };
 


### PR DESCRIPTION
Should fix this:
https://github.com/Esri/calcite-components/issues/797

Should not cause this again:
https://github.com/Esri/calcite-app-components/issues/1000

Should not cause this again:
https://github.com/Esri/calcite-app-components/issues/1044

@driskull tested this with a stand-in histogram slider and with a div with similar styling. Neither applied the z-index fix, and it seemed to be working.

Hoping that @AdelheidF can test this using the next.

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->
