### PR TITLE
docs: fix boolean attribute generation in story util

### DIFF
--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -62,7 +62,17 @@ export type Attribute = KnobbedAttribute | SimpleAttribute;
 export type Attributes = Attribute[];
 
 export const createComponentHTML = (tagName: string, attributes: Attributes, contentHTML: string = ""): string =>
-  `<${tagName} ${attributes.map(({ name, value }) => `${name}="${value}"`).join(" ")}>${contentHTML}</${tagName}>`;
+  `<${tagName} ${attributes
+    .map(({ name, value }) => {
+      const booleanAttr = typeof value === "boolean";
+
+      if (booleanAttr) {
+        return value ? name : "";
+      }
+
+      return `${name}="${value}"`;
+    })
+    .join(" ")}>${contentHTML}</${tagName}>`;
 
 export const titlelessDocsPage: typeof DocsPage = () =>
   DocsPage({


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

<!--
If this is component-related, please verify that:

- [ ] code adheres to the conventions set in `calcite-example` - https://github.com/Esri/calcite-app-components/tree/master/src/components/calcite-example
- [ ] changes have been tested with demo page in Edge
-->

This updates the component HTML util to handle boolean attributes correctly.